### PR TITLE
✨ [#13] Feat: react-daum-postcode 이용해 도로명주소 입력 폼 띄워 데이터 렌더링까지 완성

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.7.7",
     "msw": "^2.6.5",
     "react": "^18.3.1",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",
     "styled-components": "^6.1.13",

--- a/src/pages/main-page/MainPage.tsx
+++ b/src/pages/main-page/MainPage.tsx
@@ -1,10 +1,31 @@
-import { Button } from '@/components/button';
+import { useState } from 'react';
+import PostCode from './PostCode';
 
 export default function MainPage() {
+  const [address, setAddress] = useState<string>('');
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const handleSaveAddress = (newAddress: string) => {
+    setAddress(newAddress); // 저장된 주소를 업데이트
+  };
+
+  const handleAddressModal = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
   return (
     <>
-      메인페이지입니다.
-      <Button label="버튼이다" />
+      <div>
+        <div>
+          <span>
+            <strong>주소: </strong>
+            {address ? address : '주소를 입력하세요'}
+          </span>
+          <button onClick={handleAddressModal}>주소 입력</button>
+        </div>
+        {isModalOpen && <PostCode onSaveAddress={handleSaveAddress} />}
+      </div>
+      <div>해당 주소가 반영된 지도가 들어갈 자리</div>
     </>
   );
 }

--- a/src/pages/main-page/PostCode.tsx
+++ b/src/pages/main-page/PostCode.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { useDaumPostcodePopup } from 'react-daum-postcode';
+
+// daum 주소 api 반환 데이터 타입 정의
+interface PostcodeData {
+  address: string; // 기본 주소
+  addressType: 'R' | 'J'; // 'R' = 도로명 주소, 'J' = 지번 주소
+  bname: string; // 동, 리
+  buildingName: string; // 건물 이름
+}
+
+export default function PostCode({ onSaveAddress }: { onSaveAddress: (address: string) => void }) {
+  const open = useDaumPostcodePopup(); // 스크립트 URL을 자동으로 관리
+  const [fullAddress, setFullAddress] = useState<string>(''); // 전체 주소
+  const [extraAddr, setExtraAddr] = useState<string>(''); // 동, 호수같은 상세 정보 입력 상태
+
+  // handleComplete 함수에 전달되는 data의 타입을 PostcodeData로 정의
+  const handleComplete = (data: PostcodeData) => {
+    let address = data.address;
+    let extraAddress = '';
+
+    if (data.addressType === 'R') {
+      if (data.bname !== '') {
+        extraAddress += data.bname;
+      }
+      if (data.buildingName !== '') {
+        extraAddress += extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
+      }
+      address += extraAddress !== '' ? ` (${extraAddress})` : '';
+    }
+
+    setFullAddress(address); // 전체 주소 상태 갱신
+    setExtraAddr(''); // 상세주소 초기화
+
+    console.log('전체 주소:', address);
+    console.log('상세 주소:', extraAddr); // 이 값은 입력된 상세 주소가 아니라, `extraAddr`에 입력된 값임
+  };
+
+  const handleAddressPopup = () => {
+    open({ onComplete: handleComplete });
+  };
+
+  // 주소를 부모 컴포넌트로 전달해 저장
+  const handleSaveAddress = () => {
+    const fullAddressWithExtra = `${fullAddress} ${extraAddr}`.trim();
+    onSaveAddress(fullAddressWithExtra);
+  };
+
+  return (
+    <>
+      <div>
+        <span>
+          <strong>전체 주소: </strong> {fullAddress}
+        </span>
+        <button type="button" onClick={handleAddressPopup}>
+          주소검색
+        </button>
+
+        <div>
+          <label>상세 주소 (동/호수): </label>
+          <input
+            type="text"
+            value={extraAddr}
+            onChange={(e) => setExtraAddr(e.target.value)} // 상세 주소 입력 상태만 업데이트
+            placeholder="상세주소 입력해주세요"
+          />
+        </div>
+
+        <button onClick={handleSaveAddress}>주소저장</button>
+
+        {/* 주소 미리보기 저장 전에 보일 수 있게*/}
+        {/* <div>
+          <strong>상세 주소: </strong> {extraAddr}
+        </div> */}
+      </div>
+    </>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,6 +2156,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+react-daum-postcode@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz#008a0815a08fb9356fe7845d4376dcc9363f495d"
+  integrity sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==
+
 react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"


### PR DESCRIPTION
받아온 도로명 주소에서 위도, 경도를 뽑아내 카카오맵 api로 지도 이미지 띄우고, 해당 위치에 마커 표시 기능 구현해야 함

## 🔎 작업 내용

- 내용은 일단 나중에 채우겠습니다. 지금은 디코 테스트용입니다.

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #13

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->