### PR TITLE
✨[#22] Feat: label component 개발완료

### DIFF
--- a/src/components/label/AidRqCategoryLabel/index.tsx
+++ b/src/components/label/AidRqCategoryLabel/index.tsx
@@ -1,0 +1,11 @@
+import { Wrapper } from './indexCss';
+
+interface AidRqCategoryLabelProps {
+  text: string;
+}
+
+const AidRqCategoryLabel: React.FC<AidRqCategoryLabelProps> = ({ text }) => {
+  return <Wrapper>{text}</Wrapper>;
+};
+
+export default AidRqCategoryLabel;

--- a/src/components/label/AidRqCategoryLabel/indexCss.ts
+++ b/src/components/label/AidRqCategoryLabel/indexCss.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.span`
+  display: inline-block;
+  border: 1px solid #e1e1e1;
+  border-radius: 20px;
+  padding: 5px 10px;
+  color: #868686;
+  font-size: 14px;
+`;

--- a/src/components/label/AidRqCertifiedLabel/index.tsx
+++ b/src/components/label/AidRqCertifiedLabel/index.tsx
@@ -1,0 +1,7 @@
+import { Wrapper } from './indexCss';
+
+const AidRqCertifiedLabel = () => {
+  return <Wrapper>시간인증</Wrapper>;
+};
+
+export default AidRqCertifiedLabel;

--- a/src/components/label/AidRqCertifiedLabel/indexCss.ts
+++ b/src/components/label/AidRqCertifiedLabel/indexCss.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.span`
+  display: inline-block;
+  background-color: #ffd900;
+  border-radius: 20px;
+  padding: 5px 10px;
+  color: #887400;
+  font-size: 14px;
+`;

--- a/src/components/label/AidRqStateLabel/index.tsx
+++ b/src/components/label/AidRqStateLabel/index.tsx
@@ -1,0 +1,12 @@
+import { Wrapper } from './indexCss';
+
+interface AidRqStateLabelLabelProps {
+  state: string;
+}
+
+//state props로는 '모집중' / '모집완료' / '종료' 셋중 하나를 string 값으로 넣어주면 됩니다. (띄어쓰기X)
+const AidRqStateLabel: React.FC<AidRqStateLabelLabelProps> = ({ state }) => {
+  return <Wrapper state={state}>{state}</Wrapper>;
+};
+
+export default AidRqStateLabel;

--- a/src/components/label/AidRqStateLabel/indexCss.ts
+++ b/src/components/label/AidRqStateLabel/indexCss.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.span<{ state: string }>`
+  display: inline-block;
+  background-color: ${(props) =>
+    props.state === '모집중' ? '#2382FF' : props.state === '모집완료' ? '#8623FF' : '#FF6523'};
+  border-radius: 20px;
+  padding: 7px 20px;
+  color: #ffffff;
+  font-size: 14px;
+`;

--- a/src/components/label/MessageLabel/index.tsx
+++ b/src/components/label/MessageLabel/index.tsx
@@ -1,0 +1,7 @@
+import { Wrapper } from './indexCss';
+
+const MessageLabel = () => {
+  return <Wrapper>읽지않음</Wrapper>;
+};
+
+export default MessageLabel;

--- a/src/components/label/MessageLabel/indexCss.ts
+++ b/src/components/label/MessageLabel/indexCss.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.span`
+  display: inline-block;
+  background-color: #62a6ff;
+  border-radius: 20px;
+  padding: 3px 7px;
+  color: #ffffff;
+  font-size: 12px;
+`;


### PR DESCRIPTION
## 🔎 작업 내용

- label컴포넌트를 개발했습니다.
- 재사용성을 위하여 개발했고, 가져다가 쓰시면 됩니다.

- 사용방법
- AidRqCategoryLabel 의 경우 모집유형 명을 string으로 text라는 이름의 props로 넘겨주면 됩니다.
- AidRqCertifiedLabel의 경우 props는 따로 없고, 시간인증이 된 요청글에서만 넣으면 됩니다.
- AidRqStateLabel의 경우 모집상태를 '모집중' / '모집완료' / '종료' 셋중 하나의 string 값으로
state라는 이름의 props로 넘겨주면 됩니다. (띄어쓰기X)
- MessageLabel의 경우 props는 따로 없고, 읽음처리가 아직 안된 쪽지아이템에서만 넣으면 됩니다.

  <br/>

### 작업 결과 (관련 스크린샷)

![화면 캡처 2024-11-21 121458](https://github.com/user-attachments/assets/71201026-f2a6-4067-9f78-95c6a6f0fb7a)

<br/>

## 🔧 앞으로의 작업

- 수정할 부분이 있으면 수정

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

- 이해가 잘 안되거나 사용이 불편한 부분이 있으면 언제든 편하게 말씀해주세요.