### PR TITLE
✨ [#15] Feat: textArea 구현(inputBox와 기능 동일)

### DIFF
--- a/src/components/textArea/index.tsx
+++ b/src/components/textArea/index.tsx
@@ -1,0 +1,38 @@
+import TextAreaCss from './indexCss';
+import { useInput } from './logic/useInput';
+
+interface TextAreaProps {
+  getInputText: (inputText: string) => void; // inputText 상위전달
+  colortype: 0 | 1; // 색상 타입
+  width: string;
+  height?: string;
+  initialVal?: string; // input내의 초깃값
+  placeholder?: string; // input의 placeholder
+  isDisabled?: boolean;
+}
+
+const TextArea: React.FC<TextAreaProps> = ({
+  getInputText,
+  colortype = 0,
+  width,
+  height = '',
+  initialVal = '',
+  placeholder = '작성하세요.',
+  isDisabled = false
+}: TextAreaProps) => {
+  const { inputText, onChangeInput, onBlur } = useInput({ initialVal, getInputText });
+
+  return (
+    <TextAreaCss
+      width={width}
+      height={height}
+      colortype={colortype}
+      value={inputText}
+      placeholder={placeholder}
+      onChange={onChangeInput}
+      onBlur={onBlur}
+      disabled={isDisabled}
+    />
+  );
+};
+export default TextArea;

--- a/src/components/textArea/indexCss.ts
+++ b/src/components/textArea/indexCss.ts
@@ -1,0 +1,38 @@
+import { inputGray, inputWhite } from '@/styles/theme';
+import styled from 'styled-components';
+
+// colortype ? 회색입력창 : 흰색입력창
+interface TextAreaCssProps {
+  colortype: 0 | 1;
+  width: string;
+  height: string;
+}
+
+const TextAreaCss = styled.textarea<TextAreaCssProps>`
+  box-sizing: border-box;
+  outline: none;
+  resize: none;
+
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  color: ${(props) => (props.colortype ? inputGray.color : inputWhite.color)};
+  background-color: ${(props) =>
+    props.colortype ? inputGray.variants.notFocused.backgroundColor : inputWhite.backgroundColor};
+  border: ${(props) => (props.colortype ? 'none' : inputWhite.variants.notFocused.border)};
+  border-radius: ${(props) => (props.colortype ? inputGray.borderRadius : inputWhite.borderRadius)};
+  line-height: 16px;
+  font-size: 16px;
+  font-weight: 400;
+  padding: 15px;
+
+  &::placeholder {
+    color: ${(props) => (props.colortype ? inputGray.placeholderColor : inputWhite.placeholderColor)};
+  }
+
+  &:focus-within {
+    background-color: ${(props) =>
+      props.colortype ? inputGray.variants.focused.backgroundColor : inputWhite.backgroundColor};
+    border: ${(props) => (props.colortype ? 'none' : inputWhite.variants.focused.border)};
+  }
+`;
+export default TextAreaCss;

--- a/src/components/textArea/logic/useInput.ts
+++ b/src/components/textArea/logic/useInput.ts
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+interface UseInputProps {
+  getInputText: (inputText: string) => void;
+  initialVal: string;
+}
+
+interface UseInputReturn {
+  inputText: string;
+  onChangeInput: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onBlur: () => void; // 다른곳 클릭시 상위전달
+}
+
+export const useInput = ({ getInputText, initialVal }: UseInputProps): UseInputReturn => {
+  const [inputText, setInputText] = useState(initialVal);
+
+  // inputText 내부적으로 저장
+  const onChangeInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInputText(e.target.value);
+  };
+
+  // input 내부 외 다른 곳 클릭시 inputText 상위로 전달
+  const onBlur = () => {
+    getInputText(inputText);
+  };
+
+  return {
+    inputText,
+    onChangeInput,
+    onBlur
+  };
+};


### PR DESCRIPTION
## 🔎 작업 내용

> src/component/textArea/index.tsx
> src/component/textArea/indexCss.ts
> src/component/textArea/logic/useinput.ts

- inputBox와 거의 동일합니다.
- 여러 줄 입력이 가능하고 Enter키 event 삭제했습니다.
 
  <br/>

### 작업 결과 (관련 스크린샷)
![image](https://github.com/user-attachments/assets/4b525bc0-d63a-42df-83e6-91145ad8a1f3)
- inputBox와 거의 동일합니다

<br/>

## 🔧 앞으로의 작업

- 사용하면서 수정사항 필요시 고칠 생각

## 🔗 References

- Issue: #15 

## 💬 Comments
