### PR TITLE
✨ [#27] Feat: 모달 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>손모아</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.1/css/all.min.css" integrity="sha512-5Hs3dF2AEPkpNAR7UiOHba+lRSJNeM2ECkwxUIxC1Q/FLycGTbNapWXB4tP889k5T5Ju8fs4b1P5z/iB4nMfSQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,0 +1,30 @@
+import { ModalWrapper, ModalContainer, CloseButton } from './indexCss';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  variant: 'big' | 'small';
+  children?: React.ReactNode;
+}
+
+const Modal = ({ isOpen, onClose, variant, children }: ModalProps) => {
+  if (!isOpen) return null;
+
+  // 모달 내부 클릭 시 이벤트 버블링 방지
+  const handleModalClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <ModalWrapper onClick={onClose}>
+      <ModalContainer variant={variant} onClick={handleModalClick}>
+        {children}
+        <CloseButton onClick={onClose}>
+          <i className="fa-solid fa-x"></i>
+        </CloseButton>
+      </ModalContainer>
+    </ModalWrapper>
+  );
+};
+
+export default Modal;

--- a/src/components/modal/indexCss.ts
+++ b/src/components/modal/indexCss.ts
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export type ModalVariant = 'big' | 'small';
+
+export const ModalWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.48);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 50;
+`;
+
+export const ModalContainer = styled.div<{ variant: ModalVariant; width?: string; padding?: string }>`
+  background-color: #ffffff;
+  border-radius: ${theme.modal.borderRadius};
+  width: ${({ width }) => width || '90%'};
+  max-width: ${({ variant }) =>
+    variant === 'big' ? theme.modal.variants.big.width : theme.modal.variants.small.width};
+  height: ${({ variant }) => (variant === 'big' ? theme.modal.variants.big.height : theme.modal.variants.small.height)};
+  position: relative;
+  flex-direction: column;
+  padding: ${({ padding }) => padding || '2rem'};
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  width: 42px;
+  height: 42px;
+  top: 0;
+  right: -4rem;
+`;

--- a/src/components/modal/indexCss.ts
+++ b/src/components/modal/indexCss.ts
@@ -25,7 +25,6 @@ export const ModalContainer = styled.div<{ variant: ModalVariant; width?: string
   height: ${({ variant }) => (variant === 'big' ? theme.modal.variants.big.height : theme.modal.variants.small.height)};
   position: relative;
   flex-direction: column;
-  padding: ${({ padding }) => padding || '2rem'};
 `;
 
 export const CloseButton = styled.button`

--- a/src/components/modal/logic/useModal.ts
+++ b/src/components/modal/logic/useModal.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  return { isModalOpen, openModal, closeModal };
+};
+
+export default useModal;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -147,13 +147,13 @@ export const inputGray = {
 export const modal = {
   borderRadius: '25px',
   variants: {
-    // 큰모달
-    big: {
+    // 작은모달
+    small: {
       width: '800px',
       height: '500px'
     },
-    // 작은모달
-    small: {
+    // 큰모달
+    big: {
       width: '1300px',
       height: '600px'
     }


### PR DESCRIPTION
## 🔎 작업 내용

- components 폴더에 modal 폴더 생성
- logic 폴더에 모달 open, close 함수를 useModal 훅으로 만듦 -> 불러올 때 아래와 같이 불러와서 쓰면 됨
```
  const { isModalOpen, openModal, closeModal } = useModal();
  ```
- theme.ts에 있는 내용에 따라 variant를 big, small로 나누어 width, height 지정

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #27

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->