### PR TITLE
Feat/#51/물품등록기능

### DIFF
--- a/src/api/routes/index.tsx
+++ b/src/api/routes/index.tsx
@@ -4,6 +4,7 @@ import Layout from '@/layout/Layout';
 import MainPage from '@/pages/main-page/MainPage';
 import TestPage from '@/pages/test-page';
 import AidReqListPage from '@/pages/aidrq-list-page';
+import CenterPage from '@/pages/center-page';
 
 const routes: RouteObject[] = [
   {
@@ -21,6 +22,10 @@ const routes: RouteObject[] = [
       {
         path: '/aidrqlist',
         element: <AidReqListPage />
+      },
+      {
+        path: '/center',
+        element: <CenterPage />
       },
       // "/test" 경로는 아래에 둘 수 있도록 해주세요 (이 위로 라우팅 설정 해달라는 뜻입니다)
       {

--- a/src/features/edit-center-profile/indexCss.ts
+++ b/src/features/edit-center-profile/indexCss.ts
@@ -4,8 +4,7 @@ import styled from 'styled-components';
 export const CenterProfileEditContainer = styled.section`
   display: flex;
   flex-direction: column;
-  width: 90%;
-  max-width: 1200px;
+  width: 100%;
   margin: 0 auto;
   gap: 1rem;
 `;

--- a/src/features/register-goods/_components/goods-item-box/index.tsx
+++ b/src/features/register-goods/_components/goods-item-box/index.tsx
@@ -1,10 +1,16 @@
 import { GoodsItemBox, GoodsTitle, Xmark } from './indexCss';
 
-const GoodsItem = () => {
+interface GoodsItemProps {
+  centerId: number;
+  itemName: string;
+  onDelete: (centerId: number) => void;
+}
+
+const GoodsItem: React.FC<GoodsItemProps> = ({ centerId, itemName, onDelete }) => {
   return (
     <GoodsItemBox>
-      <GoodsTitle>어린이 동화 10권</GoodsTitle>
-      <Xmark className="fa-solid fa-x"></Xmark>
+      <GoodsTitle>{itemName}</GoodsTitle>
+      <Xmark className="fa-solid fa-x" onClick={() => onDelete(centerId)}></Xmark>
     </GoodsItemBox>
   );
 };

--- a/src/features/register-goods/_components/goods-item-box/index.tsx
+++ b/src/features/register-goods/_components/goods-item-box/index.tsx
@@ -1,16 +1,16 @@
 import { GoodsItemBox, GoodsTitle, Xmark } from './indexCss';
 
 interface GoodsItemProps {
-  centerId: number;
+  id: number;
   itemName: string;
-  onDelete: (centerId: number) => void;
+  onDelete: (id: number) => void;
 }
 
-const GoodsItem: React.FC<GoodsItemProps> = ({ centerId, itemName, onDelete }) => {
+const GoodsItem: React.FC<GoodsItemProps> = ({ id, itemName, onDelete }) => {
   return (
     <GoodsItemBox>
       <GoodsTitle>{itemName}</GoodsTitle>
-      <Xmark className="fa-solid fa-x" onClick={() => onDelete(centerId)}></Xmark>
+      <Xmark className="fa-solid fa-x" onClick={() => onDelete(id)}></Xmark>
     </GoodsItemBox>
   );
 };

--- a/src/features/register-goods/_components/goods-item-box/indexCss.ts
+++ b/src/features/register-goods/_components/goods-item-box/indexCss.ts
@@ -10,6 +10,7 @@ export const GoodsItemBox = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 182px;
+  gap: 5px;
 `;
 
 export const GoodsTitle = styled.p`

--- a/src/features/register-goods/_components/register-bar/index.tsx
+++ b/src/features/register-goods/_components/register-bar/index.tsx
@@ -1,25 +1,24 @@
-import InputBox from '@/components/inputBox';
-import { RegisterBarContainer, RegisterButton } from './indexCss';
+import { RegisterBarContainer, RegisterButton, RegisterInput } from './indexCss';
 
 interface RegisterBarProps {
-  inputGoods: string;
-  setInputGoods: (value: string) => void;
-  handleRegisterButton: () => void;
+  currentInput: string;
+  setCurrentInput: (value: string) => void;
+  handleAddGoods: () => void;
+  handleKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
-const RegisterBar: React.FC<RegisterBarProps> = ({ inputGoods, setInputGoods, handleRegisterButton }) => {
+const RegisterBar: React.FC<RegisterBarProps> = ({ currentInput, setCurrentInput, handleAddGoods, handleKeyPress }) => {
   return (
     <RegisterBarContainer>
-      <InputBox
-        getInputText={setInputGoods}
-        setFunc={setInputGoods}
-        colortype={1}
-        width="776px"
-        height="53px"
+      <RegisterInput
         placeholder="최대 15자 이내로 입력해주세요."
-        initialVal={inputGoods}
+        type="text"
+        value={currentInput}
+        maxLength={15}
+        onChange={(e) => setCurrentInput(e.target.value)}
+        onKeyUp={handleKeyPress}
       />
-      <RegisterButton onClick={handleRegisterButton}>등록하기</RegisterButton>
+      <RegisterButton onClick={handleAddGoods}>등록하기</RegisterButton>
     </RegisterBarContainer>
   );
 };

--- a/src/features/register-goods/_components/register-bar/index.tsx
+++ b/src/features/register-goods/_components/register-bar/index.tsx
@@ -1,18 +1,25 @@
 import InputBox from '@/components/inputBox';
 import { RegisterBarContainer, RegisterButton } from './indexCss';
 
-const RegisterBar = () => {
+interface RegisterBarProps {
+  inputGoods: string;
+  setInputGoods: (value: string) => void;
+  handleRegisterButton: () => void;
+}
+
+const RegisterBar: React.FC<RegisterBarProps> = ({ inputGoods, setInputGoods, handleRegisterButton }) => {
   return (
     <RegisterBarContainer>
       <InputBox
-        getInputText={() => console.log('입력')}
+        getInputText={setInputGoods}
+        setFunc={setInputGoods}
         colortype={1}
-        borderradius="8px"
         width="776px"
         height="53px"
         placeholder="최대 15자 이내로 입력해주세요."
+        initialVal={inputGoods}
       />
-      <RegisterButton onClick={() => console.log('클릭됨')}>등록하기</RegisterButton>
+      <RegisterButton onClick={handleRegisterButton}>등록하기</RegisterButton>
     </RegisterBarContainer>
   );
 };

--- a/src/features/register-goods/_components/register-bar/indexCss.ts
+++ b/src/features/register-goods/_components/register-bar/indexCss.ts
@@ -17,3 +17,26 @@ export const RegisterButton = styled.button`
   cursor: pointer;
   font-weight: 600;
 `;
+
+export const RegisterInput = styled.input`
+  box-sizing: border-box;
+  outline: none;
+  width: 776px;
+  height: 53px;
+  padding: 15px;
+  border: none;
+  border-radius: ${theme.inputGray.borderRadius};
+  font-size: ${theme.fontSize.seventhSize};
+  line-height: 16px;
+  background-color: ${theme.inputGray.variants.notFocused.backgroundColor};
+  color: ${theme.inputGray.color};
+
+  &::placeholder {
+    color: ${theme.inputGray.placeholderColor};
+  }
+
+  &:focus-within {
+    background-color: ${theme.inputGray.variants.focused.backgroundColor};
+    border: none;
+  }
+`;

--- a/src/features/register-goods/index.tsx
+++ b/src/features/register-goods/index.tsx
@@ -3,8 +3,33 @@ import Tooltip from '@mui/material/Tooltip';
 import { GoodsContainer, RegisterTitleSection, ResisterTitle, SectionBox, TooltipBorder } from './indexCss';
 import GoodsItem from './_components/goods-item-box';
 import RegisterBar from './_components/register-bar';
+import { useState } from 'react';
+
+interface GoodsItem {
+  centerId: number;
+  itemName: string;
+}
 
 const RegisterGoods = () => {
+  const [inputGoods, setInputGoods] = useState(''); // 입력된 값
+  const [goodsList, setGoodsList] = useState<GoodsItem[]>([]); // 이미 등록된 값 리스트
+
+  const handleRegisterButton = () => {
+    if (!inputGoods.trim()) return;
+
+    const newItem: GoodsItem = {
+      centerId: Date.now(), // TODO: 바꿀 예정 (임시) -> 키값을 고유하게 부여하여 테스트하기 위해 만들었습니다.
+      itemName: inputGoods
+    };
+
+    setGoodsList((prev) => [...prev, newItem]);
+    setInputGoods('');
+  };
+
+  const handleDeleteGoods = (centerId: number) => {
+    setGoodsList((prev) => prev.filter((item) => item.centerId !== centerId));
+  };
+
   return (
     <SectionBox>
       <RegisterTitleSection>
@@ -18,9 +43,16 @@ const RegisterGoods = () => {
         </Tooltip>
       </RegisterTitleSection>
       <GoodsContainer>
-        <GoodsItem />
+        {goodsList.map((item) => (
+          <GoodsItem
+            key={item.centerId}
+            centerId={item.centerId}
+            itemName={item.itemName}
+            onDelete={handleDeleteGoods}
+          />
+        ))}
       </GoodsContainer>
-      <RegisterBar />
+      <RegisterBar inputGoods={inputGoods} setInputGoods={setInputGoods} handleRegisterButton={handleRegisterButton} />
     </SectionBox>
   );
 };

--- a/src/features/register-goods/index.tsx
+++ b/src/features/register-goods/index.tsx
@@ -3,45 +3,11 @@ import Tooltip from '@mui/material/Tooltip';
 import { GoodsContainer, RegisterTitleSection, ResisterTitle, SectionBox, TooltipBorder } from './indexCss';
 import GoodsItem from './_components/goods-item-box';
 import RegisterBar from './_components/register-bar';
-import { useState } from 'react';
-
-interface GoodsItem {
-  id: number;
-  itemName: string;
-}
+import useHandleItem from './logic/useAddItem';
 
 const RegisterGoods = () => {
-  const [currentInput, setCurrentInput] = useState(''); // 입력된 값
-  const [goodsList, setGoodsList] = useState<GoodsItem[]>([]); // 이미 등록된 값 리스트
-
-  const handleAddGoods = () => {
-    if (!currentInput.trim()) {
-      alert('물품명을 입력해주세요.');
-      return;
-    }
-    if (currentInput.length > 15) {
-      alert('물품명은 20자 이내로 입력해주세요.');
-      return;
-    }
-
-    const newItem: GoodsItem = {
-      id: Date.now(), // TODO: 바꿀 예정 (임시) -> 키값을 고유하게 부여하여 테스트하기 위해 만들었습니다.
-      itemName: currentInput
-    };
-
-    setGoodsList((prev) => [...prev, newItem]);
-    setCurrentInput('');
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleAddGoods();
-    }
-  };
-
-  const handleDeleteGoods = (id: number) => {
-    setGoodsList((prev) => prev.filter((item) => item.id !== id));
-  };
+  const { goodsList, currentInput, setCurrentInput, handleAddGoods, handleKeyPress, handleDeleteGoods } =
+    useHandleItem();
 
   return (
     <SectionBox>

--- a/src/features/register-goods/index.tsx
+++ b/src/features/register-goods/index.tsx
@@ -6,28 +6,41 @@ import RegisterBar from './_components/register-bar';
 import { useState } from 'react';
 
 interface GoodsItem {
-  centerId: number;
+  id: number;
   itemName: string;
 }
 
 const RegisterGoods = () => {
-  const [inputGoods, setInputGoods] = useState(''); // 입력된 값
+  const [currentInput, setCurrentInput] = useState(''); // 입력된 값
   const [goodsList, setGoodsList] = useState<GoodsItem[]>([]); // 이미 등록된 값 리스트
 
-  const handleRegisterButton = () => {
-    if (!inputGoods.trim()) return;
+  const handleAddGoods = () => {
+    if (!currentInput.trim()) {
+      alert('물품명을 입력해주세요.');
+      return;
+    }
+    if (currentInput.length > 15) {
+      alert('물품명은 20자 이내로 입력해주세요.');
+      return;
+    }
 
     const newItem: GoodsItem = {
-      centerId: Date.now(), // TODO: 바꿀 예정 (임시) -> 키값을 고유하게 부여하여 테스트하기 위해 만들었습니다.
-      itemName: inputGoods
+      id: Date.now(), // TODO: 바꿀 예정 (임시) -> 키값을 고유하게 부여하여 테스트하기 위해 만들었습니다.
+      itemName: currentInput
     };
 
     setGoodsList((prev) => [...prev, newItem]);
-    setInputGoods('');
+    setCurrentInput('');
   };
 
-  const handleDeleteGoods = (centerId: number) => {
-    setGoodsList((prev) => prev.filter((item) => item.centerId !== centerId));
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleAddGoods();
+    }
+  };
+
+  const handleDeleteGoods = (id: number) => {
+    setGoodsList((prev) => prev.filter((item) => item.id !== id));
   };
 
   return (
@@ -44,15 +57,15 @@ const RegisterGoods = () => {
       </RegisterTitleSection>
       <GoodsContainer>
         {goodsList.map((item) => (
-          <GoodsItem
-            key={item.centerId}
-            centerId={item.centerId}
-            itemName={item.itemName}
-            onDelete={handleDeleteGoods}
-          />
+          <GoodsItem key={item.id} id={item.id} itemName={item.itemName} onDelete={handleDeleteGoods} />
         ))}
       </GoodsContainer>
-      <RegisterBar inputGoods={inputGoods} setInputGoods={setInputGoods} handleRegisterButton={handleRegisterButton} />
+      <RegisterBar
+        currentInput={currentInput}
+        setCurrentInput={setCurrentInput}
+        handleAddGoods={handleAddGoods}
+        handleKeyPress={handleKeyPress}
+      />
     </SectionBox>
   );
 };

--- a/src/features/register-goods/indexCss.ts
+++ b/src/features/register-goods/indexCss.ts
@@ -5,8 +5,7 @@ export const SectionBox = styled.div`
   border: ${theme.box.section.border};
   border-radius: ${theme.box.section.borderRadius};
   background-color: ${theme.box.section.backgroundColor};
-  max-width: 1200px;
-  width: 90%;
+  width: 100%;
   padding: 58px 100px 84px 80px;
   margin: auto;
 `;

--- a/src/features/register-goods/logic/useAddItem.ts
+++ b/src/features/register-goods/logic/useAddItem.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+interface GoodsItem {
+  id: number;
+  itemName: string;
+}
+
+const useHandleItem = () => {
+  const [currentInput, setCurrentInput] = useState(''); // 입력된 값
+  const [goodsList, setGoodsList] = useState<GoodsItem[]>([]); // 이미 등록된 값 리스트
+
+  const handleAddGoods = () => {
+    if (!currentInput.trim()) {
+      alert('물품명을 입력해주세요.');
+      return;
+    }
+    if (currentInput.length > 15) {
+      alert('물품명은 20자 이내로 입력해주세요.');
+      return;
+    }
+
+    const newItem: GoodsItem = {
+      id: Date.now(), // TODO: 바꿀 예정 (임시) -> 키값을 고유하게 부여하여 테스트하기 위해 만들었습니다.
+      itemName: currentInput
+    };
+
+    setGoodsList((prev) => [...prev, newItem]);
+    setCurrentInput('');
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleAddGoods();
+    }
+  };
+
+  const handleDeleteGoods = (id: number) => {
+    setGoodsList((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  return {
+    goodsList,
+    currentInput,
+    setCurrentInput,
+    handleAddGoods,
+    handleKeyPress,
+    handleDeleteGoods
+  };
+};
+
+export default useHandleItem;

--- a/src/mocks/handlers/index.tsx
+++ b/src/mocks/handlers/index.tsx
@@ -3,6 +3,7 @@ import { delay } from 'msw';
 
 // 핸들러 불러오기
 import { centerProfileHandlers } from './centerProfile-handler.mock';
+import { preferItemHandlers } from './preferItemHandler.mock';
 
 // 개발 환경에서만 작동하는 지연 함수
 export const delayForDevelopment = async (ms = 1000) => {
@@ -12,4 +13,4 @@ export const delayForDevelopment = async (ms = 1000) => {
 };
 
 // 배열 안에 mock-data 안에 있는 핸들러 spread 연산자로 불러오기
-export const handlers = [...centerProfileHandlers];
+export const handlers = [...centerProfileHandlers, ...preferItemHandlers];

--- a/src/mocks/handlers/preferItemHandler.mock.ts
+++ b/src/mocks/handlers/preferItemHandler.mock.ts
@@ -1,0 +1,71 @@
+import { http, HttpResponse } from 'msw';
+import { delayForDevelopment } from '.';
+import { mockPreferItems } from '../mock-data/goodsList.mock';
+
+interface PreferItemRequest {
+  centerId: number;
+  itemName: string;
+}
+
+export const preferItemHandlers = [
+  http.post('/api/preferItem', async ({ request }) => {
+    const requestData = (await request.json()) as PreferItemRequest;
+    console.log('MSW Handler - Request Data:', requestData);
+
+    await delayForDevelopment();
+
+    if (!requestData.centerId || !requestData.itemName.trim()) {
+      return new HttpResponse(null, {
+        status: 400,
+        statusText: '잘못된 요청입니다.'
+      });
+    }
+
+    return HttpResponse.json(
+      {
+        code: 200,
+        message: '선호물품 등록 성공',
+        data: [{}, {}]
+      },
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  }),
+
+  http.get('/api/preferItem/:centerId', async ({ params }) => {
+    const { centerId } = params;
+    console.log('MSW Handler - CenterId:', centerId);
+
+    await delayForDevelopment();
+
+    const itemData = mockPreferItems[centerId as string];
+    console.log('MSW Handler - Item Data:', itemData);
+
+    if (!itemData) {
+      return new HttpResponse(null, {
+        status: 404,
+        statusText: '선호물품 목록을 조회할 수 없습니다.'
+      });
+    }
+
+    return HttpResponse.json(
+      {
+        code: 200,
+        message: '선호물품 목록 조회 성공',
+        data: {
+          prefer_item: itemData
+        }
+      },
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  })
+];

--- a/src/pages/center-page/index.tsx
+++ b/src/pages/center-page/index.tsx
@@ -1,12 +1,13 @@
 import EditCenterProfile from '@/features/edit-center-profile';
 import RegisterGoods from '@/features/register-goods';
+import { PageWrapper } from './indexCss';
 
 const CenterPage = () => {
   return (
-    <>
+    <PageWrapper>
       <EditCenterProfile />
       <RegisterGoods />
-    </>
+    </PageWrapper>
   );
 };
 

--- a/src/pages/center-page/index.tsx
+++ b/src/pages/center-page/index.tsx
@@ -1,0 +1,13 @@
+import EditCenterProfile from '@/features/edit-center-profile';
+import RegisterGoods from '@/features/register-goods';
+
+const CenterPage = () => {
+  return (
+    <>
+      <EditCenterProfile />
+      <RegisterGoods />
+    </>
+  );
+};
+
+export default CenterPage;

--- a/src/pages/center-page/indexCss.ts
+++ b/src/pages/center-page/indexCss.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const PageWrapper = styled.div`
+  max-width: 1200px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  margin: 302px auto 250px;
+  gap: 26px;
+`;


### PR DESCRIPTION
## 🔎 작업 내용

- feature폴더에 registerGoods 폴더 생성
- goods-item 컴포넌트, register-bar 컴포넌트 생성
- 등록 input으로 필요한 물품을 직접 입력한 뒤 enter 또는 등록하기 버튼을 클릭하면 goods-item 컴포넌트가 생성
- 각 section의 너비 100%로 수정 -> page 단에서 width: 90%, max-width: 1200px 부여
- routes/index.tsx에 center 라우팅 추가
-
  <br/>

### 작업 결과 (관련 스크린샷)

<img width="668" alt="image" src="https://github.com/user-attachments/assets/d3de82ed-a6a4-494d-993c-52c8e159138d">

<br/>

## 🔧 앞으로의 작업

- react query로 api fetching

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #51

## 💬 Comments
