### PR TITLE
✨feat : 알림 토스트 및 알림전체조회 및 읽기기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-intersection-observer": "^9.13.1",
     "react-kakao-maps-sdk": "^1.1.27",
     "react-router-dom": "^6.28.0",
+    "react-toastify": "^10.0.6",
     "styled-components": "^6.1.13",
     "styled-reset": "^4.5.2",
     "zustand": "^5.0.1"

--- a/src/components/alert-item/index.tsx
+++ b/src/components/alert-item/index.tsx
@@ -3,16 +3,22 @@ import { AlertType } from '@/shared/types/alert-type/AlertType';
 
 interface AlertItemProps {
   item: AlertType;
+  sigleRead: (id: number) => void;
 }
 
-const AlertItem: React.FC<AlertItemProps> = ({ item }) => {
+const AlertItem: React.FC<AlertItemProps> = ({ item, sigleRead }) => {
   return (
     <Wrapper>
       <p>{item.type}</p>
       <p>{item.title}</p>
       <div>
         <p>2024.12.03</p>
-        <button>읽음처리하기</button>
+        <button
+          onClick={() => {
+            sigleRead(item.id);
+          }}>
+          삭제
+        </button>
       </div>
     </Wrapper>
   );

--- a/src/components/alert-item/indexCss.ts
+++ b/src/components/alert-item/indexCss.ts
@@ -38,6 +38,10 @@ export const Wrapper = styled.div`
       border-radius: 20px;
       background-color: white;
       outline: none;
+
+      &:hover {
+        cursor: pointer;
+      }
     }
   }
 `;

--- a/src/features/alert/index.tsx
+++ b/src/features/alert/index.tsx
@@ -1,12 +1,30 @@
+import { useEffect, useState } from 'react';
+
 import AlertItem from '@/components/alert-item';
 import { Container, Top, Wrapper } from './indexCss';
 import { AlertType } from '@/shared/types/alert-type/AlertType';
+import { sigleRead } from './logic/single-read';
 
-interface AlertProps {
-  notifications: AlertType[];
-}
+const Alert = () => {
+  const [notifications, setNotifications] = useState<AlertType[]>([]);
 
-const Alert: React.FC<AlertProps> = ({ notifications }) => {
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      try {
+        const response = await fetch(`${import.meta.env.VITE_APP_BASE_URL}/api/notifications/unread`, {
+          credentials: 'include'
+        });
+        const data = await response.json();
+        setNotifications(data); // data형식 보고 이부분 수정해야함
+        console.log(notifications); // cicd오류 없애기용 - set되기전에 돌아가서 의미없음
+      } catch (error) {
+        console.error('알림을 가져오는데 실패했습니다:', error);
+      }
+    };
+
+    fetchNotifications();
+  }, []);
+
   const data = [
     {
       id: 123,
@@ -50,10 +68,10 @@ const Alert: React.FC<AlertProps> = ({ notifications }) => {
       <Container>
         <Top>
           <p>알림</p>
-          <span>전체 읽음처리 하기</span>
+          <span>전체 삭제하기</span>
         </Top>
         {data.map((item) => (
-          <AlertItem item={item}></AlertItem>
+          <AlertItem key={item.id} item={item} sigleRead={sigleRead}></AlertItem>
         ))}
       </Container>
     </Wrapper>

--- a/src/features/alert/logic/single-read/index.ts
+++ b/src/features/alert/logic/single-read/index.ts
@@ -1,0 +1,3 @@
+export const sigleRead = (id: number) => {
+  console.log(id);
+};

--- a/src/layout/header/Header.tsx
+++ b/src/layout/header/Header.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 
 import { AlertBox, AlertPositioning, Contents, Logo, Menu, Wrapper } from './HeaderCss';
 import Alert from '@/features/alert';
@@ -8,22 +9,23 @@ import { AlertType } from '@/shared/types/alert-type/AlertType';
 
 export default function Header() {
   const [alertState, setAlertState] = useState(false);
-  const [notifications, setNotifications] = useState<AlertType[]>([]);
   const isLoggedIn = useLoginStore((state) => state.isLoggedIn);
 
   useEffect(() => {
     let eventSource: EventSource;
 
     const connectSSE = () => {
-      // SSE 연결 설정
       eventSource = new EventSource(`${import.meta.env.VITE_APP_BASE_URL}/api/sse/subscribe`, {
-        withCredentials: true // 쿠키를 포함 요청
+        withCredentials: true
       });
 
-      // 알림 메시지 수신 시 처리
       eventSource.onmessage = (event) => {
-        const newNotification = JSON.parse(event.data);
-        setNotifications((prev) => [...prev, newNotification]);
+        const newNotification: AlertType = JSON.parse(event.data);
+        // 새 알림이 오면 토스트 메시지 표시
+        toast.info(newNotification.title, {
+          position: 'top-right',
+          autoClose: 5000
+        });
       };
 
       // 연결 에러 처리
@@ -54,7 +56,7 @@ export default function Header() {
           <Logo>SOMEMORE</Logo>
         </Link>
         <Menu>
-          <AlertPositioning>{alertState && <Alert notifications={notifications}></Alert>}</AlertPositioning>
+          <AlertPositioning>{alertState && <Alert></Alert>}</AlertPositioning>
           <AlertBox
             onClick={() => {
               setAlertState((prev) => !prev);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,7 +1268,7 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-clsx@^2.1.1:
+clsx@^2.1.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -2674,6 +2674,13 @@ react-router@6.28.0:
   integrity sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==
   dependencies:
     "@remix-run/router" "1.21.0"
+
+react-toastify@^10.0.6:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.6.tgz#19c364b1150f495522c738d592d1dcc93879ade1"
+  integrity sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==
+  dependencies:
+    clsx "^2.1.0"
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
## 🔎 작업 내용

- sse연결 후, 알림이 오는대로 토스트버튼 띄우기 (일단 되는지 확인하고, css만질 예정)
- 종아이콘 클릭 시, 읽지않은 모든 알림들 get해오기
- 삭제버튼 클릭 시, console에 해당 알림 id 띄우도록 처리해놓음. (api개발되면 연결하면 됨)

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->