### PR TITLE
✨ [#162] community list page api 연결 및 주변 코드 수정

### DIFF
--- a/src/components/inputBox/index.tsx
+++ b/src/components/inputBox/index.tsx
@@ -11,6 +11,7 @@ interface InputCompProps {
   placeholder?: string; // input의 placeholder
   isDisabled?: boolean;
   setFunc?: (inputText: string) => void; // 상위의 set함수
+  onEnter?: () => void;
   borderRadius?: string;
 }
 
@@ -25,7 +26,7 @@ const InputBox: React.FC<InputCompProps> = ({
   isDisabled = false,
   setFunc
 }: InputCompProps) => {
-  const { inputText, onChangeInput, onEnter, onBlur } = useInput({ initialVal, getInputText, setFunc });
+  const { inputText, onChangeInput, onEnter } = useInput({ initialVal, getInputText, setFunc });
 
   return (
     <InputBoxCss
@@ -37,7 +38,7 @@ const InputBox: React.FC<InputCompProps> = ({
       placeholder={placeholder}
       onChange={onChangeInput}
       onKeyDown={onEnter}
-      onBlur={onBlur}
+      // onBlur={onBlur}
       disabled={isDisabled}
     />
   );

--- a/src/components/inputBox/logic/useInput.ts
+++ b/src/components/inputBox/logic/useInput.ts
@@ -10,7 +10,7 @@ interface UseInputReturn {
   inputText: string;
   onChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onEnter: (e: React.KeyboardEvent<HTMLInputElement>) => void; // 검색시 상위전달
-  onBlur: () => void; // 다른곳 클릭시 상위전달
+  // onBlur: () => void; // 다른곳 클릭시 상위전달
 }
 
 export const useInput = ({ getInputText, initialVal, setFunc }: UseInputProps): UseInputReturn => {
@@ -26,20 +26,20 @@ export const useInput = ({ getInputText, initialVal, setFunc }: UseInputProps): 
   const onEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       const tmp = (e.target as HTMLInputElement).value;
-      console.log('"', tmp, '" Enter가 눌렸습니다');
+      // console.log('"', tmp, '" Enter가 눌렸습니다');
       getInputText(tmp);
     }
   };
 
   // input 내부 외 다른 곳 클릭시 inputText 상위로 전달
-  const onBlur = () => {
-    getInputText(inputText);
-  };
+  // const onBlur = () => {
+  //   getInputText(inputText);
+  // };
 
   return {
     inputText,
     onChangeInput,
-    onEnter,
-    onBlur
+    onEnter
+    // onBlur
   };
 };

--- a/src/components/long-list-item/index.tsx
+++ b/src/components/long-list-item/index.tsx
@@ -1,6 +1,7 @@
 import LongListItemCss from './indexCss';
 import MailInfo from './ui/MailInfo';
 import CommunityInfo from './ui/CommunityInfo';
+import useDateFormat from '@/shared/hooks/useDateFormat';
 
 interface LongListItemProps {
   content_id: string;
@@ -11,7 +12,7 @@ interface LongListItemProps {
   mailWriter?: string;
   isRead?: boolean;
 
-  getContentId: (id: string) => void; // 클릭한 item의 content_id 반환
+  getContentId?: (id: string) => void; // 클릭한 item의 content_id 반환
 }
 
 const LongListItem: React.FC<LongListItemProps> = ({
@@ -24,15 +25,45 @@ const LongListItem: React.FC<LongListItemProps> = ({
   isRead,
   getContentId
 }) => {
-  return (
-    <LongListItemCss onClick={() => getContentId(content_id)}>
-      {indexNum ? <p className="numbering">{indexNum}</p> : ''}
-      <p className={`mainText ${isRead ? 'read' : ''}`}>{mainText}</p>
+  const { formatDate } = useDateFormat();
 
-      {modifiedDate && writer ? <CommunityInfo writer={writer} modifiedDate={modifiedDate} /> : ''}
+  if (modifiedDate && writer) {
+    // 커뮤니티 리스트 (메인페이지 & 커뮤니티리스트페이지)
+    return (
+      <LongListItemCss>
+        {indexNum ? <p className="numbering">{indexNum}</p> : ''}
+        <p
+          className={`mainText ${isRead ? 'read' : ''}`}
+          onClick={() => (getContentId ? getContentId(content_id) : '')}>
+          {mainText}
+        </p>
 
-      {mailWriter && isRead !== undefined ? <MailInfo isRead={isRead} mailWriter={mailWriter} /> : ''}
-    </LongListItemCss>
-  );
+        <CommunityInfo writer={writer} modifiedDate={formatDate(modifiedDate)} />
+      </LongListItemCss>
+    );
+  } else if (mailWriter && isRead !== undefined) {
+    // 쪽지 리스트 (개인마이페이지)
+    return (
+      <LongListItemCss>
+        <p
+          className={`mainText ${isRead ? 'read' : ''}`}
+          onClick={() => (getContentId ? getContentId(content_id) : '')}>
+          {mainText}
+        </p>
+        <MailInfo isRead={isRead} mailWriter={mailWriter} />
+      </LongListItemCss>
+    );
+  } else {
+    // 봉사 목록 (개인마이페이지)
+    return (
+      <LongListItemCss>
+        <p
+          className={`mainText ${isRead ? 'read' : ''}`}
+          onClick={() => (getContentId ? getContentId(content_id) : '')}>
+          {mainText}
+        </p>
+      </LongListItemCss>
+    );
+  }
 };
 export default LongListItem;

--- a/src/components/long-list-item/indexCss.ts
+++ b/src/components/long-list-item/indexCss.ts
@@ -12,27 +12,29 @@ const LongListItemCss = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  cursor: pointer;
+  cursor: default;
 
-  /* & * {
-    border: 1px solid gray;
-  } */
+  & * {
+    /* border: 1px solid gray; */
+
+    text-decoration-line: none;
+  }
 
   .numbering {
     padding-left: 5%;
     color: #808080;
     font-weight: 300;
     font-size: ${() => fontSize.eighthSize};
-    text-align: center;
   }
 
   .mainText {
-    margin: 0 60px 0 70px;
+    margin: 0 50px 0 50px;
     color: #000;
     font-weight: 500;
     font-size: 16px;
     text-align: left;
     width: 50%;
+    cursor: pointer;
 
     /* 길어지면 말줄임표 */
     white-space: nowrap;

--- a/src/components/long-list-item/ui/CommunityInfo.tsx
+++ b/src/components/long-list-item/ui/CommunityInfo.tsx
@@ -8,8 +8,8 @@ interface CommunityInfoProps {
 const CommunityInfo: React.FC<CommunityInfoProps> = ({ writer, modifiedDate }) => {
   return (
     <CommunityInfoCss>
-      {writer ? <p className="writer">{writer}</p> : ''}
-      {modifiedDate ? <p className="modifiedDate">{modifiedDate}</p> : ''}
+      <p className="writer">{writer}</p>
+      <p className="modifiedDate">{modifiedDate}</p>
     </CommunityInfoCss>
   );
 };

--- a/src/components/long-list-item/ui/CommunityInfoCss.ts
+++ b/src/components/long-list-item/ui/CommunityInfoCss.ts
@@ -3,11 +3,12 @@ import styled from 'styled-components';
 const CommunityInfoCss = styled.div`
   display: flex;
   justify-content: center;
-  width: 22%;
+  min-width: 22%;
+  max-width: 40%;
 
   .writer,
   .modifiedDate {
-    margin: 0 10px;
+    margin: 0 15px;
     text-align: center;
     color: #808080;
     font-weight: 300;
@@ -16,10 +17,10 @@ const CommunityInfoCss = styled.div`
   }
   .writer {
     color: #a4a4a4;
+    cursor: pointer;
 
     /* 길어지면 말줄임표 */
     white-space: nowrap;
-    overflow: hidden;
     text-overflow: ellipsis;
   }
 `;

--- a/src/components/search-bar/nonfilter-search/index.tsx
+++ b/src/components/search-bar/nonfilter-search/index.tsx
@@ -1,24 +1,33 @@
-import InputBox from '@/components/inputBox';
+import theme from '@/styles/theme';
 import { InputBoxContainer, Wrapper } from './indexCss';
 import { OtherButton } from '@/components/button';
+import InputBox from '@/components/inputBox';
 import testFunc from './logic/testFunc';
-import theme from '@/styles/theme';
+import { useState } from 'react';
 
 interface NonFilterSearchBar {
   type: boolean;
+  getInput?: (text: string) => void;
 }
 
-const NonFilterSearchBar: React.FC<NonFilterSearchBar> = ({ type }) => {
+const NonFilterSearchBar: React.FC<NonFilterSearchBar> = ({ type, getInput }) => {
+  const [word, setWord] = useState<string>('');
+  const onClickGetInput = () => {
+    if (getInput) getInput(word);
+  };
+
   return (
     <Wrapper>
       <InputBoxContainer>
         <InputBox
-          getInputText={testFunc}
+          getInputText={getInput ?? testFunc}
           width="100%"
           height={type ? '57px' : '47px'}
           borderRadius="8px"
           colortype={0}
-          placeholder="검색어를 입력해주세요."></InputBox>
+          placeholder="검색어를 입력해주세요."
+          setFunc={setWord}
+        />
       </InputBoxContainer>
       <OtherButton
         label="검색하기"
@@ -29,7 +38,9 @@ const NonFilterSearchBar: React.FC<NonFilterSearchBar> = ({ type }) => {
         color="white"
         fontSize="14px"
         fontWeight="700"
-        disabled={false}></OtherButton>
+        disabled={false}
+        onClick={onClickGetInput}
+      />
     </Wrapper>
   );
 };

--- a/src/features/community-list/index.tsx
+++ b/src/features/community-list/index.tsx
@@ -1,106 +1,41 @@
-import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { CommuntiyListCss } from './indexCss';
-import LongListItem from '@/components/long-list-item';
+import { useCommunityList } from './logic/useCommunityList';
 import { SubmitButton } from '@/components/button';
+import LongListItem from '@/components/long-list-item';
 import CustomPagination from '@/features/custom-pagnation';
+import { useLoginStore } from '@/store/stores/login/loginStore';
 
-const CommuntiyList = () => {
-  const tmpdata = [
-    {
-      id: 1,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 2,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 3,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 4,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 5,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 6,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 7,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 8,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 9,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    },
-    {
-      id: 10,
-      title: '손모아 사이트 어떤가요?',
-      write_nickname: 'jooyoug',
-      created_at: '2024.11.18'
-    }
-  ];
-
-  const onClickContent = (id: string) => {
-    // TODO: id 커뮤니티 페이지로 이동
-    console.log(id, '커뮤니티로 이동');
-  };
-
-  useEffect(() => {
-    // TODO: api/community-boards 데이터 fetch
-    console.log('TODO: api/community-boards 데이터 fetch');
-  });
-
+const CommuntiyList = ({ searchWord }: { searchWord: string }) => {
+  const { listData, totPage, currPage, setCurrPage } = useCommunityList({ searchWord });
+  const isLoggedIn = useLoginStore((state) => state.isLoggedIn);
   return (
     <CommuntiyListCss>
       <div className="listHeader">
         <i>번호</i>
         <i>제목</i>
-        <i>작성자</i>
-        <i>등록날짜</i>
+        <div>
+          <i>작성자</i>
+          <i>등록날짜</i>
+        </div>
       </div>
       <div className="listWrap">
-        {tmpdata.map((v) => (
-          <LongListItem
-            content_id={`${v.id}`}
-            indexNum={v.id}
-            mainText={v.title}
-            writer={v.write_nickname}
-            modifiedDate={v.created_at}
-            getContentId={onClickContent}
-          />
+        {listData?.map((v, i) => (
+          <Link to={`/community/${v.id}`}>
+            <LongListItem
+              key={i}
+              content_id={`${v.id}`}
+              indexNum={v.id}
+              mainText={v.title}
+              writer={v.writer_nickname}
+              modifiedDate={v.created_at}
+            />
+          </Link>
         ))}
       </div>
-      <CustomPagination />
+      <CustomPagination totPage={totPage} currPage={currPage} setCurrPage={setCurrPage} />
       <div className="btnWrap">
-        <SubmitButton label="작성하기" variant="enabledTwo" />
+        <SubmitButton label="작성하기" variant={isLoggedIn ? 'enabledTwo' : 'disabled'} />
       </div>
     </CommuntiyListCss>
   );

--- a/src/features/community-list/indexCss.ts
+++ b/src/features/community-list/indexCss.ts
@@ -8,12 +8,30 @@ export const CommuntiyListCss = styled.div`
   align-items: center;
 
   position: relative;
+  & * {
+    /* border: 1px solid gray; */
 
+    text-decoration-line: none;
+  }
   .listHeader {
     width: 100%;
-    display: grid;
-    grid-template-columns: 1fr 6fr 1fr 1fr;
-    padding: 0 12px;
+    width: 100%;
+    padding: 0 10px;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .listHeader > div {
+    display: flex;
+    justify-content: center;
+    min-width: 22%;
+    max-width: 40%;
+  }
+  .listHeader > div > i {
+    width: 100px;
+    text-align: center;
+    margin: 0 18px;
   }
   .listHeader i {
     font-size: ${theme.fontSize.seventhSize};
@@ -21,6 +39,9 @@ export const CommuntiyListCss = styled.div`
     color: #5a5a5a;
     text-align: center;
     padding-bottom: 20px;
+  }
+  .listHeader i:first-of-type {
+    padding-left: 4%;
   }
 
   .listWrap {

--- a/src/features/community-list/logic/fetchCommunityList.ts
+++ b/src/features/community-list/logic/fetchCommunityList.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+export const fetchCommunityList = async (searchWord: string, page: number = 1) => {
+  try {
+    const res = await axios.get(
+      import.meta.env.VITE_APP_BASE_URL + `/api/community-boards?keyword=${searchWord}&page=${page}`
+    );
+    console.log('fetchCommunityList data', res.data);
+
+    if (res.status === 200) return res.data;
+    else if (res.status === 400) console.log('fetchCommunityList res 400');
+    else if (res.status === 500) console.log('fetchCommunityList res 500');
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/features/community-list/logic/useCommunityList.ts
+++ b/src/features/community-list/logic/useCommunityList.ts
@@ -1,0 +1,105 @@
+import { communityListType } from '@/shared/types/community-type/CommuntiyTypes';
+import { useEffect, useState } from 'react';
+import { fetchCommunityList } from './fetchCommunityList';
+
+interface useCommunityListReturn {
+  listData: communityListType[] | undefined;
+  totPage: number;
+  currPage: number;
+  setCurrPage: (page: number) => void;
+}
+
+export const useCommunityList = ({ searchWord }: { searchWord: string }): useCommunityListReturn => {
+  const [listData, setListData] = useState<communityListType[]>();
+  const [totPage, setTotPage] = useState<number>(1);
+  const [currPage, setCurrPage] = useState<number>(1);
+
+  // 검색 또는 page 넘김 시 데이터 fetch
+  useEffect(() => {
+    console.log('searching', searchWord);
+    const fetchData = async () => {
+      const data = await fetchCommunityList(searchWord, currPage);
+      if (data) {
+        setListData(data.data.content);
+        // console.log('listData', listData);
+      }
+    };
+    fetchData();
+  }, [currPage, searchWord]);
+
+  // 첫 데이터 불러오기
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await fetchCommunityList(searchWord);
+      if (data) {
+        setListData(data.data.content);
+        setTotPage(data.data.totalPages);
+      } else
+        setListData([
+          {
+            id: 1,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 2,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 3,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 4,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 5,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 6,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 7,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 8,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 9,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          },
+          {
+            id: 10,
+            title: '손모아 사이트 어떤가요?',
+            writer_nickname: 'jooyoug',
+            created_at: '2024.11.18'
+          }
+        ]);
+    };
+    fetchData();
+  }, []);
+
+  return { listData, totPage, currPage, setCurrPage };
+};

--- a/src/pages/community-list-page/index.tsx
+++ b/src/pages/community-list-page/index.tsx
@@ -1,14 +1,17 @@
 import NonFilterSearchBar from '@/components/search-bar/nonfilter-search';
 import { Wrapper } from './indexCss';
 import CommuntiyList from '@/features/community-list';
+import { useState } from 'react';
 
 export default function CommunityListPage() {
+  const [searchWord, setSearchWord] = useState<string>('');
+
   return (
     <Wrapper>
       <div className="innerWrap">
         <i className="title">커뮤니티</i>
-        <NonFilterSearchBar type={true} />
-        <CommuntiyList />
+        <NonFilterSearchBar type={true} getInput={setSearchWord} />
+        <CommuntiyList searchWord={searchWord} />
       </div>
     </Wrapper>
   );

--- a/src/pages/main-page/_components/community/index.tsx
+++ b/src/pages/main-page/_components/community/index.tsx
@@ -3,6 +3,7 @@ import { Bottom, Title, Top, Wrapper } from './indexCss';
 import { useMainCommunity } from './logic/fetchMainCommunity';
 import { communityListType } from '@/shared/types/community-type/CommuntiyTypes';
 import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 
 const Community = () => {
   const { data, isLoading, error } = useMainCommunity();
@@ -20,7 +21,9 @@ const Community = () => {
     <Wrapper>
       <Top>
         <Title>커뮤니티</Title>
-        <button>더보기</button>
+        <Link to="/community">
+          <button>더보기</button>
+        </Link>
       </Top>
       <Bottom>
         {mainCommunity.map((item, index) => (
@@ -28,8 +31,8 @@ const Community = () => {
             key={index}
             content_id={item.id.toString()}
             mainText={item.title}
-            mailWriter={item.write_nickname}
-            modifiedDate={item.created_at.toString()}
+            writer={item.writer_nickname}
+            modifiedDate={item.created_at}
             getContentId={(id) => {
               console.log(id);
             }}></LongListItem>

--- a/src/pages/main-page/_components/community/indexCss.ts
+++ b/src/pages/main-page/_components/community/indexCss.ts
@@ -9,13 +9,14 @@ export const Top = styled.div`
   justify-content: space-between;
   padding-bottom: 30px;
 
-  & > button {
+  & button {
     font-size: 14px;
     padding: 6px 1rem;
     border: 1px solid #c7c7c7;
     border-radius: 20px;
     outline: none;
     background-color: transparent;
+    cursor: pointer;
   }
 `;
 

--- a/src/shared/types/community-type/CommuntiyTypes.ts
+++ b/src/shared/types/community-type/CommuntiyTypes.ts
@@ -1,8 +1,37 @@
+export interface communityListWrapType {
+  content: communityListType[];
+  pageable: {
+    pageNumber: number;
+    pageSize: 10;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    offset: 10;
+    paged: boolean;
+    unpaged: boolean;
+  };
+  last: boolean;
+  totalElements: 21;
+  totalPages: 3;
+  first: boolean;
+  size: 10;
+  number: 1;
+  sort: {
+    empty: boolean;
+    sorted: boolean;
+    unsorted: boolean;
+  };
+  numberOfElements: 11;
+  empty: boolean;
+}
+
 export interface communityListType {
   id: number;
   title: string;
-  write_nickname: string;
-  created_at: Date;
+  writer_nickname: string;
+  created_at: string;
 }
 
 export interface communityDetailType {


### PR DESCRIPTION
## 🔎 작업 내용

- main에서 더보기 클릭시 community list page로 이동

- Enter / 검색 버튼 클릭시 검색 데이터 fetch
- 페이지당 10개씩 가져오기, pagenation 기능 구현
- 요소 클릭시 community detail page로 이동
- 작성하기 버튼 => 개인으로 로그인시 활성화

  <br/>

### 작업 결과 (관련 스크린샷)
![image](https://github.com/user-attachments/assets/30b7f77c-7171-4b07-bf84-1d0c6e93fcf9)

<br/>

## 🔧 앞으로의 작업

- [ ] 요소 전체가 클릭되긴 하는데 제목만 cursor pointer 처리함

## 🔗 References

- Issue: #162 

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->