### PR TITLE
✨ [#182] Feat: 지도 페이지 훅 분리

### DIFF
--- a/src/components/aidrq-create-location/useKakaoLoader.tsx
+++ b/src/components/aidrq-create-location/useKakaoLoader.tsx
@@ -8,7 +8,7 @@ export default function useKakaoLoader() {
      *
      * @참고 https://apis.map.kakao.com/web/guide/
      */
-    appkey: 'b635374626f7e5479f780fe372c91367',
+    appkey: import.meta.env.VITE_APP_JAVASCRIPT_KEY,
     libraries: ['clusterer', 'drawing', 'services']
   });
 }

--- a/src/features/aidreq-detail-admin-info/_components/activity-location/index.tsx
+++ b/src/features/aidreq-detail-admin-info/_components/activity-location/index.tsx
@@ -1,3 +1,4 @@
+import useGotoKakaoMap from '@/shared/hooks/useGoToKakaoMap';
 import { SectionBox, Title } from '../../indexCss';
 import { LocationBox, LocationIcon, LocationText, MapButton } from './indexCss';
 
@@ -7,11 +8,7 @@ interface ActivityLocationProps {
   longitude: number;
 }
 const ActivityLocation = ({ address, latitude, longitude }: ActivityLocationProps) => {
-  const handleMap = () => {
-    const kakaoMapUrl = `https://map.kakao.com/link/map/${encodeURIComponent(address)},${latitude},${longitude}`;
-    window.open(kakaoMapUrl, '_blank');
-  };
-
+  const { handleMap } = useGotoKakaoMap({ address, latitude, longitude });
   return (
     <div>
       <Title>활동 위치</Title>

--- a/src/features/aidreq-detail-info/_components/location/index.tsx
+++ b/src/features/aidreq-detail-info/_components/location/index.tsx
@@ -1,3 +1,4 @@
+import useGotoKakaoMap from '@/shared/hooks/useGoToKakaoMap';
 import { Container, Wrapper } from './indexCss';
 import { AidRqDetailType } from '@/shared/types/aidrq-detail/aidrqDetailType';
 
@@ -6,15 +7,19 @@ interface AidRqDetailCenterProfileProps {
 }
 
 const Location: React.FC<AidRqDetailCenterProfileProps> = ({ data }) => {
+  const address = data.location.address;
+  const latitude = data.location.latitude;
+  const longitude = data.location.longitude;
+  const { handleMap } = useGotoKakaoMap({ address, latitude, longitude });
   return (
     <Wrapper>
       <h2>활동위치</h2>
       <Container>
         <div>
-          <img src="assets/imgs/icon-location.svg" alt=""></img>
+          <img src="/assets/imgs/icon-location.svg" alt="location-icon"></img>
           <p>{data.location.address}</p>
         </div>
-        <div>
+        <div onClick={handleMap}>
           <p>지도보기</p>
         </div>
       </Container>

--- a/src/features/find-nearby-activity-search/index.tsx
+++ b/src/features/find-nearby-activity-search/index.tsx
@@ -26,7 +26,7 @@ const FindNearByActivitySearch = ({ activities, isLoading, onSearch }: FindNearB
   };
 
   const handleActivityClick = (id: string | number) => {
-    navigate(`/centermypage/adminaidreqlist/${id}`);
+    navigate(`/aidrqdetail/${id}`);
   };
 
   return (

--- a/src/pages/find-nearby-activitiy-page/index.tsx
+++ b/src/pages/find-nearby-activitiy-page/index.tsx
@@ -12,8 +12,9 @@ const FindNearByActivityPage = () => {
   const { center, setCenter, updateCenter, setUpdateCenter, position, mapLevel, setMapLevel, setCenterToMyPosition } =
     UseMapLocation({
       initialCenter: {
-        lat: 37.26577519,
-        lng: 127.0368817
+        // 서울 특별 시청
+        lat: 37.5662,
+        lng: 126.978
       },
       initialLevel: 6
     });
@@ -34,7 +35,7 @@ const FindNearByActivityPage = () => {
   const handleActivityClick = (activity: Activity) => {
     console.log('선택한 봉사활동:', activity);
     // TODO: 지도에서 활동 마커를 클릭했을 때 실행되는 함수 -> 어떤 정보를 띄울지 고민해봐야 함
-    navigate(`/centermypage/adminaidreqlist/${activity.id}`);
+    navigate(`/aidrqdetail/${activity.id}`);
   };
 
   return (

--- a/src/shared/hooks/useGoToKakaoMap.ts
+++ b/src/shared/hooks/useGoToKakaoMap.ts
@@ -1,0 +1,18 @@
+interface useGotoKakaoMapProps {
+  address: string;
+  latitude: number;
+  longitude: number;
+}
+
+const useGotoKakaoMap = ({ address, latitude, longitude }: useGotoKakaoMapProps) => {
+  const handleMap = () => {
+    const kakaoMapUrl = `https://map.kakao.com/link/map/${encodeURIComponent(address)},${latitude},${longitude}`;
+    window.open(kakaoMapUrl, '_blank');
+  };
+
+  return {
+    handleMap
+  };
+};
+
+export default useGotoKakaoMap;


### PR DESCRIPTION
## 🔎 작업 내용

- 카카오맵 api key env 파일에 있는 환경 변수로 사용 변경
- 지도보기 클릭 -> 카카오맵 지도 길찾기 로직 훅으로 분리
- 봉사자 모집글 상세 페이지 지도 보기 버튼 클릭 시 길찾기 이동 훅 사용

  <br/>

### 작업 결과 (관련 스크린샷)

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/dc1271b5-10e4-4346-a990-ed4155057603">

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #182

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->