### PR TITLE
🐛 [#186] Fix: status !== 'COMPLETED'일 때 "정산하기"버튼 disabled 처리

### DIFF
--- a/src/features/aidreq-detail-admin-recruit-state/index.tsx
+++ b/src/features/aidreq-detail-admin-recruit-state/index.tsx
@@ -42,6 +42,7 @@ const AdminReqDetailAdminRecruitState = ({
     }
 
     updateStatus({ id, status: recruitStatusMapping[activeState] });
+    alert('모집 상태가 성공적으로 변경되었습니다.');
   };
 
   console.log('현재 active된 state', activeState);

--- a/src/pages/aidrq-detail-admin-page/index.tsx
+++ b/src/pages/aidrq-detail-admin-page/index.tsx
@@ -36,7 +36,7 @@ const AidRqDetailAdminPage = () => {
           applicantCount={recruitDetailData.recruitment_count}
         />
         <AidReqDetailAdminInfo recruitDetailData={recruitDetailData} />
-        <ButtonGroup handleAdjustmentButton={handleAdjustmentButton} />
+        <ButtonGroup handleAdjustmentButton={handleAdjustmentButton} status={recruitDetailData.recruit_status} />
       </PageWrapper>
       {openAdjustmentModal && <AdjustmentModal setOpenAdjustmentModal={setOpenAdjustmentModal} />}
     </>

--- a/src/pages/aidrq-detail-admin-page/ui/button-group/index.tsx
+++ b/src/pages/aidrq-detail-admin-page/ui/button-group/index.tsx
@@ -5,15 +5,18 @@ import { ButtonWrapper, EmptyButton } from './indexCss';
 
 interface ButtonGroupProps {
   handleAdjustmentButton: () => void;
+  status: string;
 }
 
-const ButtonGroup = ({ handleAdjustmentButton }: ButtonGroupProps) => {
+const ButtonGroup = ({ handleAdjustmentButton, status }: ButtonGroupProps) => {
   const navigate = useNavigate();
+
+  console.log('statuss', status);
 
   return (
     <ButtonWrapper>
       <EmptyButton onClick={() => navigate('/centermypage/adminaidreqmodify')}>수정하기</EmptyButton>
-      <OtherButton label="정산하기" width="221px" onClick={handleAdjustmentButton} />
+      <OtherButton label="정산하기" width="221px" onClick={handleAdjustmentButton} disabled={status !== 'COMPLETED'} />
     </ButtonWrapper>
   );
 };


### PR DESCRIPTION
## 🔎 작업 내용

- 모집 상태가 성공적으로 변환되었으면 alert창으로 "모집 상태가 성공적으로 변경 되었습니다." 띄워주었습니다. (임시로 처리해놓은 것이고, 후에 토스트나 팝업창으로 띄워주면 좋을 것 같습니다.)
- status를 props로 넘겨서 status !== 'COMPLETED' (종료)일 때 "정산하기 버튼을 disabled 처리 해놓았습니다.

  <br/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #186

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->