### PR TITLE
Feat/#268/status

### DIFF
--- a/src/features/aidreq-detail-admin-recruit-state/index.tsx
+++ b/src/features/aidreq-detail-admin-recruit-state/index.tsx
@@ -24,35 +24,70 @@ interface AdminReqDetailAdminRecruitStateProps {
   currentStatus: RecruitAPIState;
   id: number;
   applicantCount?: number;
+  startDate: string;
 }
 
 const AdminReqDetailAdminRecruitState = ({
   currentStatus,
   id,
-  applicantCount
+  applicantCount,
+  startDate
 }: AdminReqDetailAdminRecruitStateProps) => {
   const [activeState, setActiveState] = useState<RecruitUIState>(statusToKorean[currentStatus]);
   const { mutate: updateStatus, isPending: isUpdating } = useUpdateRecruitStatus();
   const { openConfirm } = useConfirmDialog();
   const { openAlert } = useAlertDialog();
 
+  // 봉사 시작 전날 자정인지 체크하는 함수
+  const isAfterDeadLine = () => {
+    const deadline = new Date(startDate);
+    deadline.setHours(0, 0, 0, 0);
+    return new Date() > deadline;
+  };
+
   const handleStatusUpdate = () => {
     if (!id || isNaN(id)) return;
 
-    if (currentStatus === 'COMPLETED' && recruitStatusMapping[activeState] !== 'COMPLETED') {
+    if (currentStatus === 'COMPLETED') {
       openAlert('종료된 모집은 상태를 변경할 수 없습니다.');
       return;
     }
 
-    updateStatus({ id, status: recruitStatusMapping[activeState] });
+    // CLOSED에서 RECRUITING으로 바꾸려는 경우
+    if (currentStatus === 'CLOSED' && recruitStatusMapping[activeState] === 'RECRUITING' && isAfterDeadLine()) {
+      openAlert('봉사 시작일 00:00 이후에는 모집중으로 상태를 변경할 수 없습니다.');
+      return;
+    }
+
     openConfirm('모집 상태를 변경하시겠습니까?', () => {
-      openAlert('모집 상태가 성공적으로 변경되었습니다.');
+      updateStatus(
+        { id, status: recruitStatusMapping[activeState] },
+        {
+          onSuccess: () => {
+            openAlert('모집 상태가 성공적으로 변경되었습니다.');
+          },
+          onError: () => {
+            openAlert('모집 상태 변경에 실패했습니다. 다시 시도해주세요.');
+          }
+        }
+      );
     });
   };
 
-  console.log('현재 active된 state', activeState);
-  console.log('지금 눌린 state', currentStatus);
-  console.log('mappedStatus:', recruitStatusMapping[activeState]);
+  // 현재 상태에 따른 버튼 비활성화
+  const isRecruitingDisabled =
+    isUpdating || currentStatus === 'COMPLETED' || (currentStatus === 'CLOSED' && isAfterDeadLine());
+  const isClosedDisabled = isUpdating || currentStatus === 'COMPLETED';
+
+  //   updateStatus({ id, status: recruitStatusMapping[activeState] });
+  //   openConfirm('모집 상태를 변경하시겠습니까?', () => {
+  //     openAlert('모집 상태가 성공적으로 변경되었습니다.');
+  //   });
+  // };
+
+  // console.log('현재 active된 state', activeState);
+  // console.log('지금 눌린 state', currentStatus);
+  // console.log('mappedStatus:', recruitStatusMapping[activeState]);
 
   return (
     <Wrapper>
@@ -62,19 +97,16 @@ const AdminReqDetailAdminRecruitState = ({
           <RecruitingButton
             isActive={activeState === '모집중'}
             onClick={() => setActiveState('모집중')}
-            disabled={isUpdating}>
+            disabled={isRecruitingDisabled}>
             <img src="/assets/imgs/recruit-active.svg" alt="모집중"></img>
           </RecruitingButton>
           <RecruitedButton
             isActive={activeState === '모집완료'}
             onClick={() => setActiveState('모집완료')}
-            disabled={isUpdating}>
+            disabled={isClosedDisabled}>
             <img src="/assets/imgs/recruit-closed.svg" alt="모집완료"></img>
           </RecruitedButton>
-          <FinishedButton
-            isActive={activeState === '종료'}
-            // onClick={() => setActiveState('종료')}
-          >
+          <FinishedButton isActive={activeState === '종료'}>
             <img src="/assets/imgs/recruit-completed.svg" alt="종료"></img>
           </FinishedButton>
           <StateText>

--- a/src/pages/aidrq-detail-admin-page/index.tsx
+++ b/src/pages/aidrq-detail-admin-page/index.tsx
@@ -36,6 +36,7 @@ const AidRqDetailAdminPage = () => {
           currentStatus={recruitDetailData.recruit_status as RecruitAPIState}
           id={parsedId}
           applicantCount={recruitDetailData.recruitment_count}
+          startDate={recruitDetailData.volunteer_start_date_time}
         />
         <AidReqDetailAdminInfo recruitDetailData={recruitDetailData} />
         <ButtonGroup


### PR DESCRIPTION
## 🔎 작업 내용

- status가 COMPLETED일 때 다른 상태 버튼 아예 못누르게 disabled처리
- 봉사시작일 00시부터는 RECRUITING으로 변경 못하도록 유효성 검증 추가


## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #268
