### PR TITLE
✨feat: 작성 수정 지원 등에 dialog추가

### DIFF
--- a/src/components/applicant-list-item/index.tsx
+++ b/src/components/applicant-list-item/index.tsx
@@ -57,7 +57,7 @@ const ApplicantListItem = ({ applicant, recruitStatus }: ApplicantListItemProps)
   };
   const handleApproveApplyment = () => {
     openConfirm(
-      `${applicant.volunteer.name}님의 지원을 수학하시겠습니까? 수학 후에도 반려하기로 변경할 수 있습니다.`,
+      `${applicant.volunteer.name}님의 지원을 수락하시겠습니까? 수락 후에도 반려하기로 변경할 수 있습니다.`,
       async () => {
         try {
           await approve(applymentId);

--- a/src/pages/aidrq-create-page/index.tsx
+++ b/src/pages/aidrq-create-page/index.tsx
@@ -9,6 +9,7 @@ import Explanation from './ui/explanation';
 import { VolunteerType, Location } from '@/shared/types/aidrq-create-type/AidRqCreateType';
 import { useNavigate } from 'react-router-dom';
 import { usePostAidRq } from '@/store/queries/aidreq-control-center-query/usePostAidRq';
+import { useAlertDialog, useConfirmDialog } from '@/store/stores/dialog/dialogStore';
 
 const AidRqCreatePage = () => {
   const navigate = useNavigate();
@@ -28,6 +29,9 @@ const AidRqCreatePage = () => {
       longitude: 0
     }
   });
+  const { openConfirm } = useConfirmDialog();
+  const { openAlert } = useAlertDialog();
+
   const getTitleAndFilter = (key: keyof VolunteerType, value: Location | string | number | boolean) => {
     setVolunteerData((prev) => ({
       ...prev,
@@ -38,10 +42,18 @@ const AidRqCreatePage = () => {
   const handleSubmit = async () => {
     try {
       await postMutation.mutateAsync({ volunteerData });
+      openAlert(`작성이 성공적으로 완료되었습니다.`);
       navigate('/main');
     } catch (error) {
+      openAlert(`작성 중 오류가 발생했습니다. 다시 시도해주세요.`);
       console.error('게시글 작성 실패:', error);
     }
+  };
+
+  const handleSubmitDialog = () => {
+    openConfirm(`작성하시겠습니까?`, () => {
+      handleSubmit();
+    });
   };
 
   return (
@@ -66,7 +78,7 @@ const AidRqCreatePage = () => {
       </FourthLine>
       <Explanation getTitleAndFilter={getTitleAndFilter}></Explanation>
       <ButtonContainer>
-        <button onClick={handleSubmit} disabled={postMutation.isPending}>
+        <button onClick={handleSubmitDialog} disabled={postMutation.isPending}>
           {postMutation.isPending ? '작성 중...' : '작성하기'}
         </button>
       </ButtonContainer>

--- a/src/pages/aidrq-detail-page/index.tsx
+++ b/src/pages/aidrq-detail-page/index.tsx
@@ -14,6 +14,7 @@ import { myPresentStatus } from '@/store/queries/aidreq-detail-volunteer-query/u
 import { PresentResponse } from '@/shared/types/aidrq-detail/PresentResponse';
 import { useFetchAidRqDetail } from '@/store/queries/aidreq-detail-volunteer-query/useFetchAidRqDetail';
 import { useApplyAidRq } from '@/store/queries/aidreq-detail-volunteer-query/useApplyAidRq';
+import { useAlertDialog, useConfirmDialog } from '@/store/stores/dialog/dialogStore';
 
 const AidRqDetailPage = () => {
   const myLoginState = useLoginStore((state) => state);
@@ -25,6 +26,8 @@ const AidRqDetailPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data: centerData } = useFetchCenterProfileForAidRq(centerId);
   const { data: data } = useFetchAidRqDetail(id);
+  const { openConfirm } = useConfirmDialog();
+  const { openAlert } = useAlertDialog();
 
   useEffect(() => {
     myPresentStatus(setPresentState, myLoginState.myLoginId, id);
@@ -37,14 +40,21 @@ const AidRqDetailPage = () => {
 
     applyAidRq(id, {
       onSuccess: () => {
-        // 성공 시 처리 (예: 알림 표시, 페이지 새로고침 등)
-        console.log('지원 성공!');
-        window.location.reload();
+        // 지원 상태 다시 조회
+        myPresentStatus(setPresentState, myLoginState.myLoginId, id);
+        // 성공 알림
+        openAlert(`지원이 성공적으로 완료되었습니다.`);
       },
       onError: (error) => {
-        // 에러 처리
+        openAlert('지원 중 오류가 발생했습니다. 다시 시도해주세요.');
         console.error('지원 실패:', error);
       }
+    });
+  };
+
+  const handleApplyDialog = () => {
+    openConfirm(`지원하시겠습니까?`, () => {
+      handleApply();
     });
   };
 
@@ -66,13 +76,9 @@ const AidRqDetailPage = () => {
           </button>
           <button
             onClick={() => {
-              const handleClick = () => {
-                if (presentState?.status === 'none' && data.recruit_status === 'RECRUITING') {
-                  handleApply();
-                  window.location.reload();
-                }
-              };
-              handleClick();
+              if (presentState?.status === 'none' && data.recruit_status === 'RECRUITING') {
+                handleApplyDialog();
+              }
             }}
             disabled={isPending}>
             지원하기

--- a/src/pages/aidrq-modify-page/ui/info-modify/index.tsx
+++ b/src/pages/aidrq-modify-page/ui/info-modify/index.tsx
@@ -5,6 +5,7 @@ import AidRqCreateDate from '@/components/aidrq-create-date';
 import TextArea from '@/components/textArea';
 import { VolunteerType } from '@/shared/types/aidrq-create-type/AidRqCreateType';
 import { updateRegular } from '@/store/queries/aidreq-control-center-query/useModifyAidRqRegular';
+import { useAlertDialog, useConfirmDialog } from '@/store/stores/dialog/dialogStore';
 
 interface InfoModifyProps {
   id: string;
@@ -13,6 +14,9 @@ interface InfoModifyProps {
 }
 
 const InfoModify: React.FC<InfoModifyProps> = ({ id, getTitleAndFilter, volunteerData }) => {
+  const { openConfirm } = useConfirmDialog();
+  const { openAlert } = useAlertDialog();
+
   if (!volunteerData) {
     return null;
   }
@@ -27,6 +31,19 @@ const InfoModify: React.FC<InfoModifyProps> = ({ id, getTitleAndFilter, voluntee
     volunteer_category: volunteerData.volunteer_category,
     admitted: volunteerData.admitted
   };
+
+  const handleUpdateInfoDialog = () => {
+    openConfirm(`정보를 수정하시겠습니까?`, () => {
+      try {
+        updateRegular(id, changedRegular);
+        openAlert(`정보가 수정되었습니다.`);
+      } catch (error) {
+        openAlert('수정 중 오류가 발생했습니다. 다시 시도해주세요.');
+        console.error('수정오류', error);
+      }
+    });
+  };
+
   return (
     <Wrapper>
       <AidRqCreateShared getTitleAndFilter={getTitleAndFilter} volunteerData={volunteerData}></AidRqCreateShared>
@@ -71,7 +88,7 @@ const InfoModify: React.FC<InfoModifyProps> = ({ id, getTitleAndFilter, voluntee
       <ButtonContainer>
         <button
           onClick={() => {
-            updateRegular(id, changedRegular);
+            handleUpdateInfoDialog();
           }}>
           수정하기
         </button>

--- a/src/pages/aidrq-modify-page/ui/info-modify/indexCss.ts
+++ b/src/pages/aidrq-modify-page/ui/info-modify/indexCss.ts
@@ -70,6 +70,11 @@ export const ButtonContainer = styled.div`
     border: none;
     outline: none;
     background-color: #2382ff;
-    font-size: 1rem;
+    font-size: 14px;
+
+    &:hover {
+      background-color: #0a66de;
+      cursor: pointer;
+    }
   }
 `;

--- a/src/pages/aidrq-modify-page/ui/location-modify/index.tsx
+++ b/src/pages/aidrq-modify-page/ui/location-modify/index.tsx
@@ -2,6 +2,7 @@ import AidRqCreateLocation from '@/components/aidrq-create-location';
 import { AidRqCreateLocationWrapper, Contents, Wrapper } from './indexCss';
 import { VolunteerType, Location } from '@/shared/types/aidrq-create-type/AidRqCreateType';
 import { updateLocation } from '@/store/queries/aidreq-control-center-query/useModifyAidRqLocation';
+import { useAlertDialog, useConfirmDialog } from '@/store/stores/dialog/dialogStore';
 
 interface LocationModifyProps {
   id: string;
@@ -10,6 +11,9 @@ interface LocationModifyProps {
 }
 
 const LocationModify: React.FC<LocationModifyProps> = ({ id, getTitleAndFilter, volunteerData }) => {
+  const { openConfirm } = useConfirmDialog();
+  const { openAlert } = useAlertDialog();
+
   if (!volunteerData) {
     return null;
   }
@@ -17,6 +21,18 @@ const LocationModify: React.FC<LocationModifyProps> = ({ id, getTitleAndFilter, 
   const changedLocation = {
     region: volunteerData.region,
     ...volunteerData.location
+  };
+
+  const handleUpdateLocationDialog = () => {
+    openConfirm(`장소를 수정하시겠습니까?`, () => {
+      try {
+        updateLocation(id, changedLocation);
+        openAlert(`장소가 수정되었습니다.`);
+      } catch (error) {
+        openAlert('수정 중 오류가 발생했습니다. 다시 시도해주세요.');
+        console.error('수정오류', error);
+      }
+    });
   };
 
   return (
@@ -31,7 +47,7 @@ const LocationModify: React.FC<LocationModifyProps> = ({ id, getTitleAndFilter, 
       </Contents>
       <button
         onClick={() => {
-          updateLocation(id, changedLocation);
+          handleUpdateLocationDialog();
         }}>
         수정하기
       </button>

--- a/src/pages/aidrq-modify-page/ui/location-modify/indexCss.ts
+++ b/src/pages/aidrq-modify-page/ui/location-modify/indexCss.ts
@@ -21,7 +21,12 @@ export const Wrapper = styled.div`
     border: none;
     outline: none;
     background-color: #2382ff;
-    font-size: 1rem;
+    font-size: 14px;
+
+    &:hover {
+      background-color: #0a66de;
+      cursor: pointer;
+    }
   }
 `;
 


### PR DESCRIPTION
## 🔎 작업 내용

- 활동 지원하기, 활동글 수정하기, 활동글 등록하기에 dialog추가
- '등록 후 새로고침 -> 등록 후 api만 재호출' 로 변경

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->