### PR TITLE
♻️ [#314] Refactor: 버튼 컴포넌트 통합

### DIFF
--- a/src/components/applicant-list-item/index.tsx
+++ b/src/components/applicant-list-item/index.tsx
@@ -1,5 +1,3 @@
-import theme from '@/styles/theme';
-import { OtherButton } from '../button';
 import {
   ApplicantListItemWrapper,
   ButtonGroup,
@@ -20,6 +18,7 @@ import ApplicantDetailModal from '@/features/applicant-detail-modal';
 import { useApproveApplyment, useRejectApplyment } from '@/store/queries/aidreq-detail-admin-query/useManageApplyment';
 import { useAlertDialog, useConfirmDialog } from '@/store/stores/dialog/dialogStore';
 import { VolunteerApply } from '@/shared/types/aidrq-volunteer-list/volunteerListType';
+import Button from '../button';
 
 interface ApplicantListItemProps {
   applicant: VolunteerApply;
@@ -101,12 +100,12 @@ const ApplicantListItem = ({ applicant, recruitStatus }: ApplicantListItemProps)
             disabled={recruitStatus === 'COMPLETED' || applicant.status === 'REJECTED'}>
             반려하기
           </RejectButton>
-          <OtherButton
+          <Button
             label="수락하기"
-            width="163px"
-            height="48px"
-            fontSize={theme.fontSize.eighthSize}
-            fontWeight="600"
+            // width="163px"
+            // height="48px"
+            // fontSize={theme.fontSize.eighthSize}
+            // fontWeight="600"
             onClick={handleApproveApplyment}
             disabled={recruitStatus === 'COMPLETED' || applicant.status === 'APPROVED'}
           />

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,4 +1,19 @@
-import OtherButton from './other-button';
-import SubmitButton from './submit-button';
+import ButtonComponent from './indexCss';
 
-export { OtherButton, SubmitButton };
+interface ButtonProps {
+  onClick?: () => void;
+  label: string;
+  disabled?: boolean;
+  type?: 'blue' | 'white';
+  className?: string;
+}
+
+const Button = ({ onClick = () => {}, label, disabled = false, type = 'blue', className }: ButtonProps) => {
+  return (
+    <ButtonComponent onClick={onClick} disabled={disabled} $type={type} className={className}>
+      {label}
+    </ButtonComponent>
+  );
+};
+
+export default Button;

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -2,16 +2,18 @@ import ButtonComponent from './indexCss';
 
 interface ButtonProps {
   onClick?: () => void;
-  label: string;
+  label?: string;
   disabled?: boolean;
   type?: 'blue' | 'white';
   className?: string;
+  children?: React.ReactNode;
 }
 
-const Button = ({ onClick = () => {}, label, disabled = false, type = 'blue', className }: ButtonProps) => {
+const Button = ({ onClick = () => {}, label, disabled = false, type = 'blue', className, children }: ButtonProps) => {
   return (
     <ButtonComponent onClick={onClick} disabled={disabled} $type={type} className={className}>
-      {label}
+      <span>{label}</span>
+      {children}
     </ButtonComponent>
   );
 };

--- a/src/components/button/indexCss.ts
+++ b/src/components/button/indexCss.ts
@@ -1,0 +1,54 @@
+import styled, { css } from 'styled-components';
+import theme from '@/styles/theme';
+
+const buttonTypes = {
+  blue: css`
+    background-color: ${theme.pointColor.Regular};
+    color: white;
+    border: none;
+
+    &:hover {
+      background-color: ${theme.pointColor.event};
+    }
+
+    &:active {
+      background-color: ${theme.pointColor.clicked};
+    }
+
+    &:disabled {
+      background-color: #e2e2e2;
+      color: #adadad;
+    }
+  `,
+
+  white: css`
+    background-color: white;
+    color: ${theme.pointColor.Regular};
+    border: 1px solid ${theme.pointColor.Regular};
+
+    &:hover {
+      border: 1px solid ${theme.pointColor.event};
+      color: ${theme.pointColor.event};
+    }
+
+    &:active {
+      border: 1px solid ${theme.pointColor.clicked};
+      color: ${theme.pointColor.clicked};
+    }
+
+    &:disabled {
+      border: 1px solid #adadad;
+      color: #adadad;
+    }
+  `
+};
+
+const ButtonComponent = styled.button<{ $type: 'blue' | 'white' }>`
+  transition: 0.3s;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+
+  ${({ $type }) => buttonTypes[$type]}
+`;
+
+export default ButtonComponent;

--- a/src/components/button/other-button/index.tsx
+++ b/src/components/button/other-button/index.tsx
@@ -1,38 +1,38 @@
-import OtherButtonComponent from './indexCss';
+// import OtherButtonComponent from './indexCss';
 
-interface OtherButtonProps extends React.ComponentProps<typeof OtherButtonComponent> {
-  onClick?: () => void; // 버튼 클릭 이벤트 핸들러
-  label: string; // 버튼에 표시될 텍스트
-}
+// interface OtherButtonProps extends React.ComponentProps<typeof OtherButtonComponent> {
+//   onClick?: () => void; // 버튼 클릭 이벤트 핸들러
+//   label: string; // 버튼에 표시될 텍스트
+// }
 
-const OtherButton = ({
-  onClick = () => {},
-  label,
-  width,
-  height,
-  border,
-  borderRadius,
-  bgColor,
-  color,
-  fontSize,
-  fontWeight,
-  disabled = false
-}: OtherButtonProps) => {
-  return (
-    <OtherButtonComponent
-      onClick={onClick}
-      width={width}
-      height={height}
-      border={border}
-      borderRadius={borderRadius}
-      bgColor={bgColor}
-      color={color}
-      fontSize={fontSize}
-      fontWeight={fontWeight}
-      disabled={disabled}>
-      {label}
-    </OtherButtonComponent>
-  );
-};
+// const OtherButton = ({
+//   onClick = () => {},
+//   label,
+//   width,
+//   height,
+//   border,
+//   borderRadius,
+//   bgColor,
+//   color,
+//   fontSize,
+//   fontWeight,
+//   disabled = false
+// }: OtherButtonProps) => {
+//   return (
+//     <OtherButtonComponent
+//       onClick={onClick}
+//       width={width}
+//       height={height}
+//       border={border}
+//       borderRadius={borderRadius}
+//       bgColor={bgColor}
+//       color={color}
+//       fontSize={fontSize}
+//       fontWeight={fontWeight}
+//       disabled={disabled}>
+//       {label}
+//     </OtherButtonComponent>
+//   );
+// };
 
-export default OtherButton;
+// export default OtherButton;

--- a/src/components/button/other-button/indexCss.ts
+++ b/src/components/button/other-button/indexCss.ts
@@ -1,47 +1,47 @@
-import theme from '@/styles/theme';
-import styled from 'styled-components';
+// import theme from '@/styles/theme';
+// import styled from 'styled-components';
 
-const OtherButtonComponent = styled.button<{
-  border?: string;
-  borderRadius?: string;
-  fontSize?: string;
-  bgColor?: string;
-  color?: string;
-  width?: string;
-  height?: string;
-  fontWeight?: string;
-  disabled?: boolean;
-}>`
-  border: ${({ border }) => border || 'none'};
-  border-radius: ${({ borderRadius }) => borderRadius || theme.submitButton.borderRadius};
-  font-size: ${({ fontSize }) => fontSize || theme.fontSize.seventhSize};
-  background-color: ${({ bgColor }) => bgColor || theme.pointColor.Regular};
-  color: ${({ color }) => color || theme.submitButton.variants.enabledOne.color};
-  width: ${({ width }) => width || '167px'};
-  height: ${({ height }) => height || '53px'};
-  font-weight: ${({ fontWeight }) => fontWeight || 'medium'};
+// const OtherButtonComponent = styled.button<{
+//   border?: string;
+//   borderRadius?: string;
+//   fontSize?: string;
+//   bgColor?: string;
+//   color?: string;
+//   width?: string;
+//   height?: string;
+//   fontWeight?: string;
+//   disabled?: boolean;
+// }>`
+//   border: ${({ border }) => border || 'none'};
+//   border-radius: ${({ borderRadius }) => borderRadius || theme.submitButton.borderRadius};
+//   font-size: ${({ fontSize }) => fontSize || theme.fontSize.seventhSize};
+//   background-color: ${({ bgColor }) => bgColor || theme.pointColor.Regular};
+//   color: ${({ color }) => color || theme.submitButton.variants.enabledOne.color};
+//   width: ${({ width }) => width || '167px'};
+//   height: ${({ height }) => height || '53px'};
+//   font-weight: ${({ fontWeight }) => fontWeight || 'medium'};
 
-  padding: 0.87rem;
-  transition:
-    background-color 0.3s ease,
-    border-color 0.3s ease,
-    color 0.3s ease;
+//   padding: 0.87rem;
+//   transition:
+//     background-color 0.3s ease,
+//     border-color 0.3s ease,
+//     color 0.3s ease;
 
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
-  &:hover {
-    background-color: ${({ disabled, bgColor }) => (disabled ? bgColor : theme.pointColor.event)}; // hover 상태
-  }
+//   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+//   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+//   &:hover {
+//     background-color: ${({ disabled, bgColor }) => (disabled ? bgColor : theme.pointColor.event)}; // hover 상태
+//   }
 
-  &:active {
-    background-color: ${({ disabled, bgColor }) => (disabled ? bgColor : theme.pointColor.clicked)}; // clicked 상태
-  }
+//   &:active {
+//     background-color: ${({ disabled, bgColor }) => (disabled ? bgColor : theme.pointColor.clicked)}; // clicked 상태
+//   }
 
-  &:disabled {
-    border: none;
-    color: #adadad;
-    background-color: #e2e2e2;
-  }
-`;
+//   &:disabled {
+//     border: none;
+//     color: #adadad;
+//     background-color: #e2e2e2;
+//   }
+// `;
 
-export default OtherButtonComponent;
+// export default OtherButtonComponent;

--- a/src/components/button/submit-button/index.tsx
+++ b/src/components/button/submit-button/index.tsx
@@ -1,34 +1,34 @@
-import SubmitButtonComponent from './indexCss';
+// import SubmitButtonComponent from './indexCss';
 
-interface SubmitButtonProps extends React.ComponentProps<typeof SubmitButtonComponent> {
-  onClick?: () => void; // 버튼 클릭 이벤트 핸들러
-  label: string; // 버튼에 표시될 텍스트
-  variant?: 'disabled' | 'enabledOne' | 'enabledTwo'; // 버튼 스타일을 위한 variant
-  height?: string;
-}
+// interface SubmitButtonProps extends React.ComponentProps<typeof SubmitButtonComponent> {
+//   onClick?: () => void; // 버튼 클릭 이벤트 핸들러
+//   label: string; // 버튼에 표시될 텍스트
+//   variant?: 'disabled' | 'enabledOne' | 'enabledTwo'; // 버튼 스타일을 위한 variant
+//   height?: string;
+// }
 
-const SubmitButton = ({
-  onClick,
-  label,
-  variant = 'enabledOne',
-  width,
-  height,
-  fontSize,
-  fontWeight,
-  disabled = false
-}: SubmitButtonProps) => {
-  return (
-    <SubmitButtonComponent
-      onClick={onClick}
-      variant={variant}
-      width={width}
-      height={height}
-      fontSize={fontSize}
-      fontWeight={fontWeight}
-      disabled={disabled}>
-      {label}
-    </SubmitButtonComponent>
-  );
-};
+// const SubmitButton = ({
+//   onClick,
+//   label,
+//   variant = 'enabledOne',
+//   width,
+//   height,
+//   fontSize,
+//   fontWeight,
+//   disabled = false
+// }: SubmitButtonProps) => {
+//   return (
+//     <SubmitButtonComponent
+//       onClick={onClick}
+//       variant={variant}
+//       width={width}
+//       height={height}
+//       fontSize={fontSize}
+//       fontWeight={fontWeight}
+//       disabled={disabled}>
+//       {label}
+//     </SubmitButtonComponent>
+//   );
+// };
 
-export default SubmitButton;
+// export default SubmitButton;

--- a/src/components/button/submit-button/indexCss.ts
+++ b/src/components/button/submit-button/indexCss.ts
@@ -1,79 +1,79 @@
-import styled from 'styled-components';
-import { submitButton } from '@/styles/theme';
-import theme from '@/styles/theme';
+// import styled from 'styled-components';
+// import { submitButton } from '@/styles/theme';
+// import theme from '@/styles/theme';
 
-export type ButtonVariant = 'disabled' | 'enabledOne' | 'enabledTwo';
+// export type ButtonVariant = 'disabled' | 'enabledOne' | 'enabledTwo';
 
-const SubmitButtonComponent = styled.button<{
-  variant?: ButtonVariant;
-  width?: string;
-  height?: string;
-  fontSize?: string;
-  fontWeight?: string;
-}>`
-  border-radius: ${submitButton.borderRadius};
-  width: ${({ width }) => width || '220px'};
-  height: ${({ height }) => height || ''};
-  font-size: ${({ fontSize }) => fontSize || theme.fontSize.seventhSize};
-  font-weight: ${({ fontWeight }) => fontWeight || 'bold'};
-  cursor: ${({ variant }) => (variant === 'disabled' ? 'not-allowed' : 'pointer')};
+// const SubmitButtonComponent = styled.button<{
+//   variant?: ButtonVariant;
+//   width?: string;
+//   height?: string;
+//   fontSize?: string;
+//   fontWeight?: string;
+// }>`
+//   border-radius: ${submitButton.borderRadius};
+//   width: ${({ width }) => width || '220px'};
+//   height: ${({ height }) => height || ''};
+//   font-size: ${({ fontSize }) => fontSize || theme.fontSize.seventhSize};
+//   font-weight: ${({ fontWeight }) => fontWeight || 'bold'};
+//   cursor: ${({ variant }) => (variant === 'disabled' ? 'not-allowed' : 'pointer')};
 
-  padding: 0.87rem;
-  transition:
-    background-color 0.3s ease,
-    border-color 0.3s ease,
-    color 0.3s ease;
+//   padding: 0.87rem;
+//   transition:
+//     background-color 0.3s ease,
+//     border-color 0.3s ease,
+//     color 0.3s ease;
 
-  // 기본 스타일
-  background-color: ${({ variant }) =>
-    variant === 'disabled'
-      ? submitButton.variants.disabled.backgroundColor
-      : variant === 'enabledOne'
-        ? submitButton.variants.enabledOne.backgroundColor
-        : submitButton.variants.enabledTwo.backgroundColor};
+//   // 기본 스타일
+//   background-color: ${({ variant }) =>
+//     variant === 'disabled'
+//       ? submitButton.variants.disabled.backgroundColor
+//       : variant === 'enabledOne'
+//         ? submitButton.variants.enabledOne.backgroundColor
+//         : submitButton.variants.enabledTwo.backgroundColor};
 
-  color: ${({ variant }) =>
-    variant === 'disabled'
-      ? submitButton.variants.disabled.color
-      : variant === 'enabledOne'
-        ? submitButton.variants.enabledOne.color
-        : submitButton.variants.enabledTwo.color};
+//   color: ${({ variant }) =>
+//     variant === 'disabled'
+//       ? submitButton.variants.disabled.color
+//       : variant === 'enabledOne'
+//         ? submitButton.variants.enabledOne.color
+//         : submitButton.variants.enabledTwo.color};
 
-  border: ${({ variant }) => (variant === 'enabledTwo' ? submitButton.variants.enabledTwo.border : 'none')};
+//   border: ${({ variant }) => (variant === 'enabledTwo' ? submitButton.variants.enabledTwo.border : 'none')};
 
-  pointer-events: ${({ variant }) => (variant === 'disabled' ? 'none' : 'auto')};
+//   pointer-events: ${({ variant }) => (variant === 'disabled' ? 'none' : 'auto')};
 
-  // Hover 상태
-  &:hover {
-    ${({ variant }) =>
-      variant === 'enabledOne' &&
-      `
-        background-color: ${theme.pointColor.event};
-      `}
+//   // Hover 상태
+//   &:hover {
+//     ${({ variant }) =>
+//       variant === 'enabledOne' &&
+//       `
+//         background-color: ${theme.pointColor.event};
+//       `}
 
-    ${({ variant }) =>
-      variant === 'enabledTwo' &&
-      `
-        border-color: ${theme.pointColor.event};
-        color: ${theme.pointColor.event};
-      `}
-  }
+//     ${({ variant }) =>
+//       variant === 'enabledTwo' &&
+//       `
+//         border-color: ${theme.pointColor.event};
+//         color: ${theme.pointColor.event};
+//       `}
+//   }
 
-  // Active 상태
-  &:active {
-    ${({ variant }) =>
-      variant === 'enabledOne' &&
-      `
-        background-color: ${theme.pointColor.clicked};
-      `}
+//   // Active 상태
+//   &:active {
+//     ${({ variant }) =>
+//       variant === 'enabledOne' &&
+//       `
+//         background-color: ${theme.pointColor.clicked};
+//       `}
 
-    ${({ variant }) =>
-      variant === 'enabledTwo' &&
-      `
-        border-color: ${theme.pointColor.clicked};
-        color: ${theme.pointColor.clicked};
-      `}
-  }
-`;
+//     ${({ variant }) =>
+//       variant === 'enabledTwo' &&
+//       `
+//         border-color: ${theme.pointColor.clicked};
+//         color: ${theme.pointColor.clicked};
+//       `}
+//   }
+// `;
 
-export default SubmitButtonComponent;
+// export default SubmitButtonComponent;

--- a/src/components/search-bar/filter-search/ui/filter-box/index.tsx
+++ b/src/components/search-bar/filter-search/ui/filter-box/index.tsx
@@ -1,10 +1,9 @@
 import { Wrapper, SelectWrapper } from './indexCss';
-import { OtherButton } from '@/components/button';
 import Select from '@/components/select';
-import theme from '@/styles/theme';
 import aidrqCategoryMapping from '@/shared/mapping/aidrq-category-mapping';
 import regionMapping from '@/shared/mapping/aid-region-mapping';
 import admittedMapping from '@/shared/mapping/aid-admitted-mapping';
+import Button from '@/components/button';
 
 interface FilterBoxProps {
   setSearchState: (state: {
@@ -80,17 +79,17 @@ const FilterBox: React.FC<FilterBoxProps> = ({ setSearchState, searchAidRequests
             });
           }}></Select>
       </SelectWrapper>
-      <OtherButton
+      <Button
         onClick={searchAidRequests}
         label="검색하기"
-        width="188px"
-        border={`1px solid ${theme.pointColor.Regular}`}
-        borderRadius="8px"
-        bgColor={theme.pointColor.Regular}
-        color="white"
-        fontSize="16px"
-        fontWeight="700"
-        disabled={false}></OtherButton>
+        // width="188px"
+        // border={`1px solid ${theme.pointColor.Regular}`}
+        // borderRadius="8px"
+        // bgColor={theme.pointColor.Regular}
+        // color="white"
+        // fontSize="16px"
+        // fontWeight="700"
+        disabled={false}></Button>
     </Wrapper>
   );
 };

--- a/src/components/search-bar/nonfilter-search/index.tsx
+++ b/src/components/search-bar/nonfilter-search/index.tsx
@@ -1,8 +1,7 @@
-import theme from '@/styles/theme';
 import { InputBoxContainer, Wrapper } from './indexCss';
-import { OtherButton } from '@/components/button';
 import InputBox from '@/components/inputBox';
 import { useState } from 'react';
+import Button from '@/components/button';
 
 interface NonFilterSearchBar {
   type: boolean;
@@ -32,15 +31,15 @@ const NonFilterSearchBar: React.FC<NonFilterSearchBar> = ({ type, getInput }) =>
           setFunc={setWord}
         />
       </InputBoxContainer>
-      <OtherButton
+      <Button
         label="검색하기"
-        width={type ? '188px' : '100px'}
-        border={`1px solid ${theme.pointColor.Regular}`}
-        borderRadius="8px"
-        bgColor={theme.pointColor.Regular}
-        color="white"
-        fontSize="14px"
-        fontWeight="700"
+        // width={type ? '188px' : '100px'}
+        // border={`1px solid ${theme.pointColor.Regular}`}
+        // borderRadius="8px"
+        // bgColor={theme.pointColor.Regular}
+        // color="white"
+        // fontSize="14px"
+        // fontWeight="700"
         disabled={false}
         onClick={onClickGetInput}
       />

--- a/src/features/adjustment-modal/index.tsx
+++ b/src/features/adjustment-modal/index.tsx
@@ -1,6 +1,4 @@
-import { OtherButton } from '@/components/button';
 import Modal from '@/components/modal';
-import theme from '@/styles/theme';
 import {
   AdjustmentSubTitle,
   AdjustmentTitle,
@@ -20,6 +18,7 @@ import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useSettleApplyment } from '@/store/queries/aidreq-detail-admin-query/useManageApplyment';
 import { VolunteerApply } from '@/shared/types/aidrq-volunteer-list/volunteerListType';
+import Button from '@/components/button';
 
 interface AdjustmentModalProps {
   setOpenAdjustmentModal: (isOpen: boolean) => void;
@@ -113,12 +112,12 @@ const AdjustmentModal = ({ setOpenAdjustmentModal }: AdjustmentModalProps) => {
             ))}
           </ApplicantList>
           <ButtonBox>
-            <OtherButton
+            <Button
               label="정산하기"
-              width="163px"
-              height="48px"
-              fontSize={theme.fontSize.eighthSize}
-              fontWeight="600"
+              // width="163px"
+              // height="48px"
+              // fontSize={theme.fontSize.eighthSize}
+              // fontWeight="600"
               onClick={handleSettle}
               disabled={!hasUnsettledParticipants}
             />

--- a/src/features/aidreq-detail-admin-recruit-state/index.tsx
+++ b/src/features/aidreq-detail-admin-recruit-state/index.tsx
@@ -127,8 +127,8 @@
 
 // export default AdminReqDetailAdminRecruitState;
 
-import { OtherButton } from '@/components/button';
 import {
+  ApplyButton,
   ButtonBox,
   FinishedButton,
   NumberOfPeople,
@@ -244,10 +244,11 @@ const AdminReqDetailAdminRecruitState = ({
         </RecruitStateButtonContainer>
       </StateContainer>
       <ButtonBox>
-        <OtherButton
+        <ApplyButton
           label="상태 변경 적용"
           onClick={handleStatusUpdate}
           disabled={isUpdating || recruitStatusMapping[activeState] === currentStatus}
+          type="blue"
         />
       </ButtonBox>
     </Wrapper>

--- a/src/features/aidreq-detail-admin-recruit-state/indexCss.ts
+++ b/src/features/aidreq-detail-admin-recruit-state/indexCss.ts
@@ -1,3 +1,4 @@
+import Button from '@/components/button';
 import theme from '@/styles/theme';
 import styled from 'styled-components';
 
@@ -82,4 +83,12 @@ export const ButtonBox = styled.div`
   width: 100%;
   display: flex;
   justify-content: end;
+`;
+
+export const ApplyButton = styled(Button)`
+  width: 221px;
+  height: 53px;
+  border-radius: 13px;
+  font-size: 14px;
+  font-weight: 600;
 `;

--- a/src/features/aidreq-detail-center-profile/_components/button-container/index.tsx
+++ b/src/features/aidreq-detail-center-profile/_components/button-container/index.tsx
@@ -1,10 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import { Dispatch, SetStateAction } from 'react';
 
-import { OtherButton } from '@/components/button';
 import { MailButton, Wrapper } from './indexCss';
-import theme from '@/styles/theme';
 import { centerProfileType } from '@/shared/types/center-profile/centerProfile';
+import Button from '@/components/button';
 
 interface ButtonContainerProps {
   centerProfile: centerProfileType;
@@ -16,20 +15,20 @@ const ButtonContainer: React.FC<ButtonContainerProps> = ({ centerProfile, setIsM
 
   return (
     <Wrapper>
-      <OtherButton
+      <Button
         onClick={() => {
           navigate(`/centerprofile/${centerProfile.center_id}`);
         }}
         label="프로필 보러가기"
-        width="220px"
-        height="47px"
-        border={`1px solid ${theme.pointColor.Regular}`}
-        borderRadius="8px"
-        bgColor={theme.pointColor.Regular}
-        color="white"
-        fontSize="14px"
-        fontWeight="400"
-        disabled={false}></OtherButton>
+        // width="220px"
+        // height="47px"
+        // border={`1px solid ${theme.pointColor.Regular}`}
+        // borderRadius="8px"
+        // bgColor={theme.pointColor.Regular}
+        // color="white"
+        // fontSize="14px"
+        // fontWeight="400"
+        disabled={false}></Button>
       <MailButton
         onClick={() => {
           setIsModalOpen(true);

--- a/src/features/communitiy-detail-comment-box/ui/CommentInput.tsx
+++ b/src/features/communitiy-detail-comment-box/ui/CommentInput.tsx
@@ -1,5 +1,5 @@
+import Button from '@/components/button';
 import { CommentInputCss } from './CommentInputCss';
-import { SubmitButton } from '@/components/button';
 import InputBox from '@/components/inputBox';
 
 const CommentInput = ({
@@ -21,7 +21,7 @@ const CommentInput = ({
         setFunc={setCommentText}
         onEnterFunc={onEventPost}
       />
-      <SubmitButton label="댓글 등록" onClick={onEventPost} />
+      <Button label="댓글 등록" onClick={onEventPost} />
     </CommentInputCss>
   );
 };

--- a/src/features/communitiy-detail-content-box/index.tsx
+++ b/src/features/communitiy-detail-content-box/index.tsx
@@ -1,6 +1,6 @@
+import Button from '@/components/button';
 import { CommunityDetailContentBoxCss } from './indexCss';
 import { useCommunityDetailContent } from './logic/useCommunityDetailContent';
-import { SubmitButton } from '@/components/button';
 import WriterProfileBox from './ui/WriterProfileBox';
 import useDateFormat from '@/shared/hooks/useDateFormat';
 import { Link } from 'react-router-dom';
@@ -23,7 +23,7 @@ const CommunityDetailContentBox = ({ content_id }: { content_id: number }) => {
         <div className="btnWrap">
           {isMyContent ? (
             <Link to={`/communitycreate/${content_id}`}>
-              <SubmitButton label="수정하기" />
+              <Button label="수정하기" />
             </Link>
           ) : (
             ''

--- a/src/features/communitiy-detail-content-box/ui/WriterProfileBox.tsx
+++ b/src/features/communitiy-detail-content-box/ui/WriterProfileBox.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { WriterProfileBoxCss } from './WriterProfileBoxCss';
-import { SubmitButton } from '@/components/button';
 import { tierType } from '@/shared/types/person-profile/personProfile';
+import Button from '@/components/button';
 
 const WriterProfileBox = ({
   volunteer_id,
@@ -23,10 +23,12 @@ const WriterProfileBox = ({
       </div>
       {volunteer_id ? (
         <Link to={`/profile/${volunteer_id}`}>
-          <SubmitButton label="프로필 확인하기" variant="enabledOne" />
+          {/* <SubmitButton label="프로필 확인하기" variant="enabledOne" /> 이걸 아래로 바꿔놨어요 밑에꺼 수정하면 이건 지우시면 됩니다. */}
+          <Button label="프로필 확인하기" />
         </Link>
       ) : (
-        <SubmitButton label="프로필 확인하기" variant="disabled" />
+        // <SubmitButton label="프로필 확인하기" variant="disabled" /> 이걸 아래로 바꿔놨어요 밑에꺼 수정하면 이건 지우시면 됩니다.
+        <Button label="프로필 확인하기" />
       )}
     </WriterProfileBoxCss>
   );

--- a/src/features/community-create-box/index.tsx
+++ b/src/features/community-create-box/index.tsx
@@ -1,9 +1,9 @@
 import { CommunityCreateBoxCss } from './indexCss';
 import { useCreateCommunity } from './logic/useCreateCommunity';
-import { SubmitButton } from '@/components/button';
 import InputBox from '@/components/inputBox';
 import TextArea from '@/components/textArea';
 import UploadBox from '@/components/img-drag-box';
+import Button from '@/components/button';
 
 const CommunityCreateBox = ({ content_id }: { content_id?: number }) => {
   const { titleText, setTitleText, contentText, setContentText, handleFileSelect, onClickPost } = useCreateCommunity({
@@ -41,7 +41,7 @@ const CommunityCreateBox = ({ content_id }: { content_id?: number }) => {
       </div>
 
       <div className="btnWrap">
-        <SubmitButton label="작성하기" onClick={onClickPost} />
+        <Button label="작성하기" onClick={onClickPost} />
       </div>
     </CommunityCreateBoxCss>
   );

--- a/src/features/community-list/index.tsx
+++ b/src/features/community-list/index.tsx
@@ -1,16 +1,16 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { CommuntiyListCss } from './indexCss';
-import { SubmitButton } from '@/components/button';
 import LongListItem from '@/components/long-list-item';
 import CustomPagination from '@/features/custom-pagnation';
-import { useLoginStore } from '@/store/stores/login/loginStore';
+// import { useLoginStore } from '@/store/stores/login/loginStore';
 import { useCommunityList } from '@/store/queries/community-list-common-query/useCommunityList';
+import Button from '@/components/button';
 
 const CommuntiyList = ({ searchWord }: { searchWord: string }) => {
   const { listData, totPage, currPage, setCurrPage } = useCommunityList({
     searchWord
   });
-  const isLoggedIn = useLoginStore((state) => state.isLoggedIn);
+  // const isLoggedIn = useLoginStore((state) => state.isLoggedIn); 버튼 커스텀 하실 때 풀어서 써주세요..!
   const navigate = useNavigate();
   return (
     <CommuntiyListCss>
@@ -37,9 +37,9 @@ const CommuntiyList = ({ searchWord }: { searchWord: string }) => {
       </div>
       <CustomPagination totPage={totPage} currPage={currPage} setCurrPage={setCurrPage} />
       <div className="btnWrap">
-        <SubmitButton
+        <Button
           label="작성하기"
-          variant={isLoggedIn ? 'enabledTwo' : 'disabled'}
+          // variant={isLoggedIn ? 'enabledTwo' : 'disabled'} 버튼 커스텀 하실 때 풀어서 써주세요..!
           onClick={() => {
             navigate('/communitycreate');
           }}

--- a/src/features/edit-center-profile/index.tsx
+++ b/src/features/edit-center-profile/index.tsx
@@ -1,4 +1,4 @@
-import { OtherButton } from '@/components/button';
+import Button from '@/components/button';
 import ImageUploader from './_components/image-uploader';
 import EditProfileForm from './_components/profile-edit-form/index';
 import {
@@ -68,9 +68,9 @@ const EditCenterProfile = ({ data }: EditCenterProfileProps) => {
           />
         </ProfileEditWrapper>
         <EditButtonContainer>
-          <OtherButton
+          <Button
             label="수정하기"
-            width="220px"
+            // width="220px"
             onClick={handleEditProfile}
             disabled={isSubmitting || !validURL || !validPhone || !centerName.trim()}
           />

--- a/src/features/find-nearby-activity-map/index.tsx
+++ b/src/features/find-nearby-activity-map/index.tsx
@@ -84,8 +84,7 @@ const FindNearByActivityMap = ({
           ))}
 
         <LocationButtonBox>
-          <NearbyButton onClick={onNearbyClick}>
-            현재 위치에서 재검색
+          <NearbyButton onClick={onNearbyClick} label="현재 위치에서 재검색" type="white">
             <RefreshIcon src="/assets/imgs/icon-refresh.svg" alt="현재위치에서검색" />
           </NearbyButton>
           <MyLocationButton onClick={handleMyLocationClick}>

--- a/src/features/find-nearby-activity-map/indexCss.ts
+++ b/src/features/find-nearby-activity-map/indexCss.ts
@@ -1,3 +1,4 @@
+import Button from '@/components/button';
 import theme from '@/styles/theme';
 import styled, { keyframes } from 'styled-components';
 
@@ -34,7 +35,7 @@ export const MyLocationButton = styled.button`
   justify-content: center;
 `;
 
-export const NearbyButton = styled.button`
+export const NearbyButton = styled(Button)`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -52,6 +53,7 @@ export const NearbyButton = styled.button`
   &:active {
     color: ${theme.pointColor.clicked};
     border: 1px solid ${theme.pointColor.clicked};
+    background-color: #d9e8fa;
   }
 `;
 

--- a/src/features/find-nearby-activity-search/index.tsx
+++ b/src/features/find-nearby-activity-search/index.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MapPageTitle, ScrollSection, SearchBarComponent, SearchBox, Wrapper } from './indexCss';
+import { MapPageTitle, ScrollSection, SearchBarComponent, SearchBox, SearchButton, Wrapper } from './indexCss';
 import AidReqListItem from '@/components/aidreq-list-Item';
 import InputBox from '@/components/inputBox';
 import type { Activity } from '@/shared/types/location/nearbyLocation';
-import Button from '@/components/button';
 
 interface FindNearByActivitySearchProps {
   activities: Activity[];
@@ -34,14 +33,7 @@ const FindNearByActivitySearch = ({ activities, isLoading, onSearch }: FindNearB
         <MapPageTitle>주변 활동 찾기</MapPageTitle>
         <SearchBarComponent>
           <InputBox colortype={0} width="80%" getInputText={handleInputChange} />
-          <Button
-            label="검색"
-            // width="80px"
-            // height="47px"
-            // fontSize={theme.fontSize.seventhSize}
-            // fontWeight="600"
-            onClick={handleSearch}
-          />
+          <SearchButton label="검색" onClick={handleSearch} />
         </SearchBarComponent>
         <Wrapper>
           {!isLoading &&

--- a/src/features/find-nearby-activity-search/index.tsx
+++ b/src/features/find-nearby-activity-search/index.tsx
@@ -3,9 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { MapPageTitle, ScrollSection, SearchBarComponent, SearchBox, Wrapper } from './indexCss';
 import AidReqListItem from '@/components/aidreq-list-Item';
 import InputBox from '@/components/inputBox';
-import { OtherButton } from '@/components/button';
-import theme from '@/styles/theme';
 import type { Activity } from '@/shared/types/location/nearbyLocation';
+import Button from '@/components/button';
 
 interface FindNearByActivitySearchProps {
   activities: Activity[];
@@ -35,12 +34,12 @@ const FindNearByActivitySearch = ({ activities, isLoading, onSearch }: FindNearB
         <MapPageTitle>주변 활동 찾기</MapPageTitle>
         <SearchBarComponent>
           <InputBox colortype={0} width="80%" getInputText={handleInputChange} />
-          <OtherButton
+          <Button
             label="검색"
-            width="80px"
-            height="47px"
-            fontSize={theme.fontSize.seventhSize}
-            fontWeight="600"
+            // width="80px"
+            // height="47px"
+            // fontSize={theme.fontSize.seventhSize}
+            // fontWeight="600"
             onClick={handleSearch}
           />
         </SearchBarComponent>

--- a/src/features/find-nearby-activity-search/indexCss.ts
+++ b/src/features/find-nearby-activity-search/indexCss.ts
@@ -1,3 +1,4 @@
+import Button from '@/components/button';
 import theme from '@/styles/theme';
 import styled from 'styled-components';
 
@@ -50,4 +51,12 @@ export const Wrapper = styled.ul`
   gap: 10px;
   width: 100%;
   justify-content: center;
+`;
+
+export const SearchButton = styled(Button)`
+  width: 80px;
+  height: 47px;
+  font-size: ${theme.fontSize.seventhSize};
+  font-weight: 600;
+  border-radius: 12px;
 `;

--- a/src/features/login-feature/_components/org-login/index.tsx
+++ b/src/features/login-feature/_components/org-login/index.tsx
@@ -1,7 +1,7 @@
 import { OrgLoginCss } from './indexCss';
-import { SubmitButton } from '@/components/button';
 import InputBox from '@/components/inputBox';
 import { useOrgLogin } from './logic/useOrgLogin';
+import Button from '@/components/button';
 
 const OrgLogin = () => {
   const { idErr, pwdErr, checkId, checkPwd, onClickFindAcount, onClickLogin, onClickFirstVisit } = useOrgLogin();
@@ -37,7 +37,7 @@ const OrgLogin = () => {
         <button className="findAccountBtn" onClick={onClickFindAcount}>
           계정 찾기
         </button>
-        <SubmitButton label="로그인" width="49%" height="55px" onClick={onClickLogin} />
+        <Button label="로그인" onClick={onClickLogin} />
       </div>
       <button className="firstVisitBtn" onClick={onClickFirstVisit}>
         첫방문이신가요?

--- a/src/features/message-create-modal/index.tsx
+++ b/src/features/message-create-modal/index.tsx
@@ -1,10 +1,10 @@
 import { MessageCreateModalCss } from './indexCss';
 import { useSendMail } from './logic/useSendMail';
-import { SubmitButton } from '@/components/button';
 import InputBox from '@/components/inputBox';
 import TextArea from '@/components/textArea';
 import Modal from '@/components/modal';
 import { useAlertDialog } from '@/store/stores/dialog/dialogStore'; // AlertDialog import 추가
+import Button from '@/components/button';
 
 interface MessageCreateModalProps {
   user_id: string;
@@ -56,10 +56,10 @@ const MessageCreateModal: React.FC<MessageCreateModalProps> = ({ user_id, isModa
           </div>
           <div className="btnWrap">
             <i className="checkErr">{errMsg}</i>
-            <SubmitButton
+            <Button
               label="전송"
               onClick={handleSendClick} // Alert 포함한 함수 호출
-              variant={errMsg ? 'disabled' : 'enabledOne'}
+              // variant={errMsg ? 'disabled' : 'enabledOne'} 버튼 커스텀 하실 때 풀어서 써주세요..!
             />
           </div>
         </div>

--- a/src/features/message-read-modal/index.tsx
+++ b/src/features/message-read-modal/index.tsx
@@ -13,11 +13,10 @@ import {
   ProfileInfo,
   ScrollSection
 } from './indexCss';
-import { OtherButton } from '@/components/button';
-import theme from '@/styles/theme';
 import { useNavigate } from 'react-router-dom';
 import { useApplicantDetail, useMessageDetail } from '@/store/queries/center-mypage/useMessage';
 import useDateFormat from '@/shared/hooks/useDateFormat';
+import Button from '@/components/button';
 
 interface NoteModalProps {
   handleModalClose: () => void;
@@ -67,12 +66,12 @@ const MessageReadModal = ({ handleModalClose, noteId, type = 'center' }: NoteMod
                 ''
               )}
             </ProfileInfo>
-            <OtherButton
+            <Button
               label="프로필 확인하기"
-              width="221px"
-              height="53px"
-              fontSize={theme.fontSize.eighthSize}
-              fontWeight="600"
+              // width="221px"
+              // height="53px"
+              // fontSize={theme.fontSize.eighthSize}
+              // fontWeight="600"
               onClick={() => {
                 if (type === 'center') navigate(`/profile/${messageDetail.sender_id}`);
                 else navigate(`/centerprofile/${messageDetail.sender_id}`);

--- a/src/features/personal-my-page-edit-profile/index.tsx
+++ b/src/features/personal-my-page-edit-profile/index.tsx
@@ -1,8 +1,8 @@
 import { EditProfileCss } from './indexCss';
-import { SubmitButton } from '@/components/button';
 import InputWithLabel from '@/features/input-with-label/InputWithLabel';
 import EditProfileImg from './_component/EditProfileImg';
 import { useEditMyProfile } from './logic/useEditMyProfile';
+import Button from '@/components/button';
 
 interface EditProfileProps {
   profileImg?: string;
@@ -30,7 +30,7 @@ const EditProfile: React.FC<EditProfileProps> = ({ profileImg, profileNickname, 
           isTextArea={true}
         />
         <div className="editBtnWrap">
-          <SubmitButton label="수정하기" onClick={onClickEditMyProfile} />
+          <Button label="수정하기" onClick={onClickEditMyProfile} />
         </div>
       </section>
     </EditProfileCss>

--- a/src/features/profile-page-img-box/index.tsx
+++ b/src/features/profile-page-img-box/index.tsx
@@ -1,9 +1,9 @@
-import { SubmitButton } from '@/components/button';
 import { ProfileImgBoxCss } from './indexCss';
 import { personProfileType } from '@/shared/types/person-profile/personProfile';
 import { centerProfileType } from '@/shared/types/center-profile/centerProfile';
-import { useLoginStore } from '@/store/stores/login/loginStore';
+// import { useLoginStore } from '@/store/stores/login/loginStore';  버튼 커스텀 하실 때 풀어서 써주세요..!
 import InterestHeartBtn from '@/components/interest-heart';
+import Button from '@/components/button';
 
 type personOrCenter = ({ type: 'person' } & personProfileType) | ({ type: 'center' } & centerProfileType);
 
@@ -13,8 +13,8 @@ type ProfileImgBoxProps = {
 
 const ProfileImgBox: React.FC<ProfileImgBoxProps> = (props) => {
   const { setIsModalOpen } = props;
-  const isLoggedIn = useLoginStore((state) => state.isLoggedIn);
-  const loginType = useLoginStore((state) => state.loginType);
+  // const isLoggedIn = useLoginStore((state) => state.isLoggedIn); 버튼 커스텀 하실 때 풀어서 써주세요..!
+  // const loginType = useLoginStore((state) => state.loginType); 버튼 커스텀 하실 때 풀어서 써주세요..!
 
   // 타입 가드 함수 생성
   const isPersonProfile = (props: personOrCenter): props is { type: 'person' } & personProfileType => {
@@ -33,10 +33,10 @@ const ProfileImgBox: React.FC<ProfileImgBoxProps> = (props) => {
           <img className="mitten" src={`/assets/imgs/mitten-${tier.toLowerCase()}.svg`} />
         </p>
         {/* 봉사자는 봉사자에게 쪽지 보낼 수 없음 */}
-        <SubmitButton
+        <Button
           label="쪽지 전달하기"
           onClick={() => setIsModalOpen(true)}
-          variant={isLoggedIn && loginType === 'ROLE_CENTER' ? 'enabledOne' : 'disabled'}
+          // variant={isLoggedIn && loginType === 'ROLE_CENTER' ? 'enabledOne' : 'disabled'} 버튼 커스텀 하실 때 풀어서 써주세요..!
         />
       </ProfileImgBoxCss>
     );
@@ -52,10 +52,10 @@ const ProfileImgBox: React.FC<ProfileImgBoxProps> = (props) => {
           <i>{homepage_link}</i>
         </p>
         {/* 센터는 센터에게 쪽지 보낼 수 없음 */}
-        <SubmitButton
+        <Button
           label="쪽지 전달하기"
           onClick={() => setIsModalOpen(true)}
-          variant={isLoggedIn && loginType === 'ROLE_VOLUNTEER' ? 'enabledOne' : 'disabled'}
+          // variant={isLoggedIn && loginType === 'ROLE_VOLUNTEER' ? 'enabledOne' : 'disabled'}
         />
       </ProfileImgBoxCss>
     );

--- a/src/features/review-read-modal/index.tsx
+++ b/src/features/review-read-modal/index.tsx
@@ -15,12 +15,11 @@ import {
   ReviewTitleBox,
   ScrollSection
 } from './indexCss';
-import { OtherButton } from '@/components/button';
-import theme from '@/styles/theme';
 import { useNavigate } from 'react-router-dom';
 import useDateFormat from '@/shared/hooks/useDateFormat';
 import { useGetReviewById } from '@/store/queries/center-mypage/useReview';
 import { useGetOtherVolunteerProfile } from '@/store/queries/volunteer-profile/useVolunteerProfile';
+import Button from '@/components/button';
 
 interface ReviewModalProps {
   handleCloseReviewModal: () => void;
@@ -63,12 +62,12 @@ const ReviewReadModal = ({ handleCloseReviewModal, reviewId }: ReviewModalProps)
               <NickName>{volunteerData.nickname}</NickName>
               <GloveImg src={`/assets/imgs/mitten-${volunteerData?.tier?.toLowerCase()}.svg`} alt="tierGlove" />
             </ProfileInfo>
-            <OtherButton
+            <Button
               label="프로필 확인하기"
-              width="221px"
-              height="53px"
-              fontSize={theme.fontSize.eighthSize}
-              fontWeight="600"
+              // width="221px"
+              // height="53px"
+              // fontSize={theme.fontSize.eighthSize}
+              // fontWeight="600"
               onClick={() => {
                 navigate(`/profile/${volunteerData.volunteer_id}`);
               }}

--- a/src/pages/aidrq-detail-admin-page/ui/button-group/index.tsx
+++ b/src/pages/aidrq-detail-admin-page/ui/button-group/index.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
-import { OtherButton } from '@/components/button';
 import { ButtonWrapper, EmptyButton } from './indexCss';
+import Button from '@/components/button';
 
 interface ButtonGroupProps {
   id: string | undefined;
@@ -22,7 +22,7 @@ const ButtonGroup = ({ id, handleAdjustmentButton, status }: ButtonGroupProps) =
         }>
         수정하기
       </EmptyButton>
-      <OtherButton label="정산하기" width="221px" onClick={handleAdjustmentButton} disabled={status !== 'COMPLETED'} />
+      <Button label="정산하기" onClick={handleAdjustmentButton} disabled={status !== 'COMPLETED'} />
     </ButtonWrapper>
   );
 };

--- a/src/pages/center-contact-page/ui/contact-form/index.tsx
+++ b/src/pages/center-contact-page/ui/contact-form/index.tsx
@@ -1,8 +1,8 @@
 import InputBox from '@/components/inputBox';
 import { Form, FormContainer, FormGroup, FormRow, FormTitle, ImageUploadArea, Label, UploadIcon } from './indexCss';
 import TextArea from '@/components/textArea';
-import { OtherButton } from '@/components/button';
 import { ButtonBox } from '@/features/adjustment-modal/indexCss';
+import Button from '@/components/button';
 
 const ContactForm = () => {
   return (
@@ -89,7 +89,7 @@ const ContactForm = () => {
         </FormGroup>
 
         <ButtonBox>
-          <OtherButton type="submit" label="작성하기" width="220px" height="53px" />
+          <Button label="작성하기" />
         </ButtonBox>
       </Form>
     </FormContainer>


### PR DESCRIPTION
## 🔎 작업 내용

- submit, other 버튼을 button으로 통합하기 위해 새로 만들었습니다. 
- props로는 type('blue' or 'white'), label, onClick, disabled를 전달하고 있고 내부에서는 기본적으로 type, hover, active, disabled 스타일 처리를 하고 있습니다. 
- 직접 쓸 때에는 아래 이미지처럼 css를 스타일링을 직접하여 사용 가능합니다. 

  <br/>

### 작업 결과 (관련 스크린샷)

<img width="737" alt="image" src="https://github.com/user-attachments/assets/5a7583a2-ec88-4a2a-83be-f7caca461727" />
<img width="562" alt="image" src="https://github.com/user-attachments/assets/16649f65-a990-4985-abcf-2e8ea68e0629" />

**적용 방법**
<img width="581" alt="image" src="https://github.com/user-attachments/assets/333734dd-5846-4d53-9888-9b9dbae29cd1" />
<img width="318" alt="image" src="https://github.com/user-attachments/assets/61fcbb45-e491-4b3e-94cf-2cd831db3ee0" />

**적용 화면**
<img width="206" alt="image" src="https://github.com/user-attachments/assets/8664bc29-754e-4438-8ae9-980ead57cf0f" />
<img width="190" alt="image" src="https://github.com/user-attachments/assets/3f2560eb-618d-4fcb-8524-13b649151fbf" />

<br/>

## 🔧 앞으로의 작업

Submit, Other 버튼이 쓰인 부분들 전부 수정 필요, 
컴포넌트를 쓰지 않고 자체적으로 만든 버튼들도 컴포넌트로 변경 필요

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #314