### PR TITLE
✨feat:main에서 관심기관 리스트 불러와서 저장

### DIFF
--- a/src/pages/main-page/MainPage.tsx
+++ b/src/pages/main-page/MainPage.tsx
@@ -8,23 +8,20 @@ import Ranking from './_components/ranking';
 import Community from './_components/community';
 import { useLoginStore } from '@/store/stores/login/loginStore';
 import axiosInstance from '@/api/apis';
+import useInterestStore from '@/store/stores/interest-center/interestStore';
 // import LocalTestBox from './_components/localTestBox';
 // import LocalTestBoxVolun from './_components/localTestBoxVolun';
 
 export default function MainPage() {
   const loginType = useLoginStore((state) => state.loginType);
   const setLoginInfo = useLoginStore((state) => state.setLoginInfo);
+  const setCenterIds = useInterestStore((state) => state.setCenterIds);
 
   useEffect(() => {
-    //
-    //
-    //
-    //로컬개발환경에서 주석을 달고 사용하세요.
+    // 응답으로 받은 로그인 정보를 zustand에 저장
     const getLoginInfo = async () => {
       try {
         const response = await axiosInstance.get('/api/token/userinfo');
-        // 응답으로 받은 로그인 정보를 zustand에 저장
-        console.log(response.data);
         const USER_ID = response.data.USER_ID;
         const ROLE = response.data.ROLE;
         if (ROLE === 'ROLE_CENTER' || ROLE === 'ROLE_VOLUNTEER') setLoginInfo(USER_ID, ROLE);
@@ -34,6 +31,23 @@ export default function MainPage() {
     };
     getLoginInfo();
   }, []);
+
+  useEffect(() => {
+    // 응답으로 받은 관심기관 리스트를 zustand에 저장
+    const getInterestCenter = async () => {
+      try {
+        const response = await axiosInstance.get('/api/interest-centers');
+        const centerList = response.data;
+        console.log('관심기관 리스트', centerList);
+        setCenterIds(centerList);
+      } catch (error) {
+        console.error('로그인 정보 가져오기 실패:', error);
+      }
+    };
+    if (loginType === 'ROLE_VOLUNTEER') {
+      getInterestCenter();
+    }
+  }, [loginType]);
 
   return (
     <Wrapper>

--- a/src/store/stores/interest-center/interestStore.ts
+++ b/src/store/stores/interest-center/interestStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist, StateStorage } from 'zustand/middleware';
+
+interface interestCenterType {
+  center_id: string;
+  center_name: string;
+  img_url: string;
+}
+
+interface InterestStore {
+  centerIds: Set<string>;
+  setCenterIds: (interests: interestCenterType[]) => void;
+  addCenterId: (id: string) => void;
+  removeCenterId: (id: string) => void;
+}
+
+// Set을 직렬화/역직렬화하기 위한 custom storage
+const customStorage: StateStorage = {
+  getItem: (name: string) => {
+    const str = localStorage.getItem(name);
+    if (!str) return null;
+    return str;
+  },
+  setItem: (name: string) => {
+    try {
+      const currentState = useInterestStore.getState();
+
+      // 현재 상태의 centerIds를 배열로 변환하여 저장
+      const serializedValue = JSON.stringify({
+        state: {
+          centerIds: Array.from(currentState.centerIds)
+        },
+        version: 0
+      });
+      localStorage.setItem(name, serializedValue);
+    } catch (error) {
+      console.error('Error storing data:', error);
+    }
+  },
+  removeItem: (name: string) => localStorage.removeItem(name)
+};
+
+const useInterestStore = create<InterestStore>()(
+  persist(
+    (set) => ({
+      centerIds: new Set<string>(),
+
+      setCenterIds: (interests) => {
+        const ids = new Set(interests.map((interest) => interest.center_id));
+        set({ centerIds: ids });
+      },
+
+      addCenterId: (id) =>
+        set((state) => {
+          const newIds = new Set(state.centerIds);
+          newIds.add(id);
+          return { centerIds: newIds };
+        }),
+
+      removeCenterId: (id) =>
+        set((state) => {
+          const newIds = new Set(state.centerIds);
+          newIds.delete(id);
+          return { centerIds: newIds };
+        })
+    }),
+    {
+      name: 'interest-storage',
+      storage: createJSONStorage(() => customStorage)
+    }
+  )
+);
+
+export default useInterestStore;


### PR DESCRIPTION
## 🔎 작업 내용

- 메인페이지에서 관심기관 불러와서 저장
- local과 연동

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- detail페이지 들어갈때 관심기관 여부 판별하기
- interest heart 클릭 시에 zustand와 연동시키기

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->