### PR TITLE
♻️ [#347] Fix: 에러 페이지 라우팅 주소 "/error"로 변경

### DIFF
--- a/src/api/routes/index.tsx
+++ b/src/api/routes/index.tsx
@@ -141,7 +141,7 @@ const routes: RouteObject[] = [
         element: <LoginErrorPage />
       },
       {
-        path: '/*',
+        path: '/error',
         element: <NotFoundPage />
       }
     ]


### PR DESCRIPTION
## 🔎 작업 내용

- "/*" 경로였던 에러 페이지를 "/error"로 변경

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #347

