### PR TITLE
🐛 [#370] Fix: 물품등록 ui 즉시 반영되도록 수정

### DIFF
--- a/src/features/register-goods/index.tsx
+++ b/src/features/register-goods/index.tsx
@@ -6,8 +6,8 @@ import RegisterBar from './_components/register-bar';
 import useHandleItem from './logic/useAddItem';
 import type { centerPreferItemType } from '@/shared/types/center-profile/centerProfile';
 import { usePreferItem } from '@/store/queries/center-mypage/usePreferItems';
-import { useQuery } from '@tanstack/react-query';
 import { useAlertDialog } from '@/store/stores/dialog/dialogStore';
+// import { useQuery } from '@tanstack/react-query';
 
 interface RegisterGoodsProps {
   name: string;
@@ -16,17 +16,7 @@ interface RegisterGoodsProps {
 
 const RegisterGoods = ({ name, preferData }: RegisterGoodsProps) => {
   const { addItem, isLoading } = usePreferItem();
-  const { data: preferItems } = useQuery({
-    queryKey: ['preferItems'],
-    initialData: preferData,
-    staleTime: 1000 * 60 * 5,
-    refetchOnWindowFocus: false
-    // refetchOnMount: true
-  });
-
-  const { goodsList, currentInput, setCurrentInput, handleKeyPress, handleDeleteGoods, addGoodsToList } =
-    useHandleItem(preferItems);
-
+  const { currentInput, setCurrentInput, handleKeyPress, handleDeleteGoods } = useHandleItem();
   const { openAlert } = useAlertDialog();
 
   const handleAdd = async (itemName: string) => {
@@ -40,14 +30,7 @@ const RegisterGoods = ({ name, preferData }: RegisterGoodsProps) => {
     }
 
     addItem(itemName, {
-      onSuccess: (response) => {
-        // 새 아이템을 로컬 상태에 추가 -> 즉시 ui에 반영하기 위해
-        const newItem: centerPreferItemType = {
-          id: response.id,
-          centerId: response.centerId,
-          itemName: response.itemName
-        };
-        addGoodsToList(newItem);
+      onSuccess: () => {
         setCurrentInput('');
       },
       onError: (error) => {
@@ -70,7 +53,7 @@ const RegisterGoods = ({ name, preferData }: RegisterGoodsProps) => {
         </Tooltip>
       </RegisterTitleSection>
       <GoodsContainer>
-        {goodsList.map((item) => (
+        {preferData.map((item) => (
           <GoodsItem key={item.id} prefer_item_id={item.id} item_name={item.itemName} onDelete={handleDeleteGoods} />
         ))}
       </GoodsContainer>

--- a/src/features/register-goods/index.tsx
+++ b/src/features/register-goods/index.tsx
@@ -7,7 +7,6 @@ import useHandleItem from './logic/useAddItem';
 import type { centerPreferItemType } from '@/shared/types/center-profile/centerProfile';
 import { usePreferItem } from '@/store/queries/center-mypage/usePreferItems';
 import { useAlertDialog } from '@/store/stores/dialog/dialogStore';
-// import { useQuery } from '@tanstack/react-query';
 
 interface RegisterGoodsProps {
   name: string;

--- a/src/features/register-goods/logic/useAddItem.ts
+++ b/src/features/register-goods/logic/useAddItem.ts
@@ -1,16 +1,8 @@
-import type { centerPreferItemType } from '@/shared/types/center-profile/centerProfile';
 import { useDeletePreferItem } from '@/store/queries/center-mypage/usePreferItems';
 import { useState } from 'react';
 
-const useHandleItem = (preferData: centerPreferItemType[]) => {
+const useHandleItem = () => {
   const [currentInput, setCurrentInput] = useState('');
-  const [goodsList, setGoodsList] = useState<centerPreferItemType[]>(preferData); // 이미 등록된 값 리스트
-
-  // 로컬 상태 업데이트 함수 -> 즉시 반영
-  const addGoodsToList = (newItem: centerPreferItemType) => {
-    setGoodsList((prev) => [...prev, newItem]);
-  };
-
   const { mutate: deleteItem } = useDeletePreferItem();
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>, handleAdd: (input: string) => void) => {
@@ -20,20 +12,14 @@ const useHandleItem = (preferData: centerPreferItemType[]) => {
   };
 
   const handleDeleteGoods = (itemId: number) => {
-    setGoodsList((prev) => prev.filter((item) => item.id !== itemId));
-
     deleteItem(itemId);
   };
 
   return {
-    goodsList,
-    setGoodsList,
     currentInput,
     setCurrentInput,
     handleKeyPress,
-    handleDeleteGoods,
-    addGoodsToList
+    handleDeleteGoods
   };
 };
-
 export default useHandleItem;

--- a/src/pages/center-my-page/index.tsx
+++ b/src/pages/center-my-page/index.tsx
@@ -17,8 +17,6 @@ const CenterMyPage = () => {
   if (error) return <div>에러 발생: ${error.message}</div>;
   if (!data) return null;
 
-  // console.log('데이터다!', data);
-
   return (
     <PageWrapper>
       <EditCenterProfile data={data} />

--- a/src/store/queries/center-mypage/usePreferItems.ts
+++ b/src/store/queries/center-mypage/usePreferItems.ts
@@ -1,23 +1,9 @@
 import axiosInstance from '@/api/apis';
-import { centerPreferItemType } from '@/shared/types/center-profile/centerProfile';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-// import Cookies from 'js-cookie';
 
 // 물품 POST fetch 함수
 const addPreferItem = async (itemName: string) => {
-  // const response = await axiosInstance.post<PreferItemResponse>(
-  //   '/api/preferItem',
-  //   {
-  //     item_name: itemName
-  //   },
-  //   {
-  //     headers: {
-  //       Authorization: `${Cookies.get('ACCESS')}`
-  //     }
-  //   }
-  // );
-
-  const response = await axiosInstance.post<centerPreferItemType>('/api/preferItem', {
+  const response = await axiosInstance.post('/api/preferItem', {
     item_name: itemName
   });
 
@@ -32,7 +18,7 @@ export const usePreferItem = () => {
     mutationFn: addPreferItem,
     onSuccess: (data) => {
       // 데이터 post 성공시
-      queryClient.invalidateQueries({ queryKey: ['preferItems'] });
+      queryClient.invalidateQueries({ queryKey: ['centerProfile'] });
       console.log('물품등록 완료!', data);
     },
     onError: (error) => {
@@ -49,12 +35,6 @@ export const usePreferItem = () => {
 
 // 기관 물품 삭제 api ------------------------------------------------------
 const deletePreferItem = async (preferItemId: number) => {
-  // const response = await axiosInstance.delete(`/api/preferItem/${preferItemId}`, {
-  //   headers: {
-  //     Authorization: `Bearer ${Cookies.get('ACCESS')}`
-  //   }
-  // });
-
   const response = await axiosInstance.delete(`/api/preferItem/${preferItemId}`);
   return response.data;
 };
@@ -66,7 +46,7 @@ export const useDeletePreferItem = () => {
     mutationFn: deletePreferItem,
     onSuccess: () => {
       // 삭제 성공시 물품 리스트 갱신
-      queryClient.invalidateQueries({ queryKey: ['preferItems'] });
+      queryClient.invalidateQueries({ queryKey: ['centerProfile'] });
       console.log('물품삭제가 완료되었습니다.');
     },
     onError: (error) => {


### PR DESCRIPTION
## 🔎 작업 내용

- 물품 등록 쿼리 키는 preferItem, 프로필 조회할 때 쓰이는 쿼리키는 centerProfile이었는데, 
물품등록 응답은 centerProfile에 포함되기 때문에 물품 등록 post, delete 요청의 쿼리키도 preferItem -> centerProfile로 맞춤
- react query의 invalidateQueries로 캐시 무효화를 하기 위해서는 useState로 로컬 즉시 반영되는 부분을 지워야 했음

  <br/>

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #370
