### PR TITLE
🐛 [#390] Fix: 지원자현황 단건 조회에서 지원자 이메일 필드 삭제

### DIFF
--- a/src/features/applicant-detail-modal/index.tsx
+++ b/src/features/applicant-detail-modal/index.tsx
@@ -83,10 +83,10 @@ const ApplicantDetailModal: React.FC<ApplicantDetailModalProps> = ({ handleOpenD
               <Key>전화번호</Key>
               <Value>{applicantDetail.detail.contact_number}</Value>
             </DetailItem>
-            <DetailItem>
+            {/* <DetailItem>
               <Key>이메일</Key>
               <Value>{applicantDetail.detail.email}</Value>
-            </DetailItem>
+            </DetailItem> */}
           </SectionBox>
         </ScrollSection>
       </ModalWrapper>

--- a/src/features/applicant-detail-modal/indexCss.ts
+++ b/src/features/applicant-detail-modal/indexCss.ts
@@ -128,4 +128,5 @@ export const SectionBox = styled.ul`
 
 export const DetailItem = styled.li`
   display: flex;
+  align-items: center;
 `;


### PR DESCRIPTION
## 🔎 작업 내용-

- 기관이 조회할 수 있는 봉사활동 지원자 현황 페이지의 단건 조회 모달에서, 
지원자 상세 프로필 get 요청에서 이메일 필드 삭제

### 작업 결과 (관련 스크린샷)

<img width="587" alt="image" src="https://github.com/user-attachments/assets/170e71d7-be69-4d59-8b2b-a4d630596b26" />


## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #390