### PR TITLE
♻️ [#397] Refactor: 활동구인 페이지 도움요청글 리스트 Wrapper에 margin: auto 설정

### DIFF
--- a/src/features/aidrq-list-regular/indexCss.ts
+++ b/src/features/aidrq-list-regular/indexCss.ts
@@ -6,4 +6,5 @@ export const Wrapper = styled.ul`
   flex-wrap: wrap;
   max-width: 1200px;
   width: 90%;
+  margin: auto;
 `;


### PR DESCRIPTION
## 🔎 작업 내용
- 왼쪽으로 치우쳐져 있길래 aidList Wrapper에 margin: auto 추가했습니다.

  <br/>

### 작업 결과 (관련 스크린샷)

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/f0ae9376-d1f4-44ce-952b-e1e7d4687a5e" />

<br/>


## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #397 