### PR TITLE
Feat/#421/기관모집글관리

### DIFF
--- a/src/pages/admin-aidrq-list-page/index.tsx
+++ b/src/pages/admin-aidrq-list-page/index.tsx
@@ -1,6 +1,6 @@
 import FilterSearchBar from '@/components/search-bar/filter-search';
 import WriteAidReqButtonComponent from '@/components/write-aidreq-button';
-import { PageWrapper, Title } from './indexCss';
+import { PageWrapper, TabButtonWrapper, Title } from './indexCss';
 import TabButtonGroup from '@/components/tab-button';
 import AidRqAdminListWrapper from './_components/aidrqlistadmin-wrapper';
 import useAdminSearchStore from '@/store/stores/admin-search/searchStore';
@@ -33,10 +33,12 @@ const AdminAidRqListPage = () => {
       <Title>내가 등록한 도움요청 글</Title>
       <WriteAidReqButtonComponent />
       <FilterSearchBar searchAidRequests={searchAidRequests} />
-      <TabButtonGroup
-        onTabChange={handleTabChange}
-        tabs={[{ label: '모집중' }, { label: '모집완료' }, { label: '모집종료' }]}
-      />
+      <TabButtonWrapper>
+        <TabButtonGroup
+          onTabChange={handleTabChange}
+          tabs={[{ label: '모집중' }, { label: '모집완료' }, { label: '모집종료' }]}
+        />
+      </TabButtonWrapper>
       <AidRqAdminListWrapper centerId={centerId} />
     </PageWrapper>
   );

--- a/src/pages/admin-aidrq-list-page/indexCss.ts
+++ b/src/pages/admin-aidrq-list-page/indexCss.ts
@@ -10,10 +10,19 @@ export const PageWrapper = styled.div`
   padding: 250px 0;
   gap: 56px;
   align-items: center;
+
+  @media (max-width: 1000px) {
+    width: 90%;
+  }
 `;
 
 export const Title = styled.p`
   font-size: ${theme.fontSize.secondSize};
   font-weight: 700;
   text-align: center;
+
+  @media (max-width: 1000px) {
+    font-size: ${theme.fontSize.fifthSize};
+    width: 100%;
+  }
 `;

--- a/src/pages/admin-aidrq-list-page/indexCss.ts
+++ b/src/pages/admin-aidrq-list-page/indexCss.ts
@@ -16,6 +16,10 @@ export const PageWrapper = styled.div`
   }
 `;
 
+export const TabButtonWrapper = styled.div`
+  width: 100%;
+`;
+
 export const Title = styled.p`
   font-size: ${theme.fontSize.secondSize};
   font-weight: 700;

--- a/src/pages/center-my-page/indexCss.ts
+++ b/src/pages/center-my-page/indexCss.ts
@@ -6,7 +6,7 @@ export const PageWrapper = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 auto;
-  padding: 150px 0 200px 0;
+  padding: 250px 0;
   gap: 26px;
 
   @media (max-width: 1000px) {


### PR DESCRIPTION
## 🔎 작업 내용

- title 폰트 사이즈 수정, width: 100% 적용
- pageWrapper에 max-width: 1000px일 떄 width: 90% 적용
- TabButtonGroup 컴포넌트에 TabButtonWrapper div 추가하여 width: 100% 적용

  <br/>

### 작업 결과 (관련 스크린샷)

<img width="334" alt="image" src="https://github.com/user-attachments/assets/fd4babe0-4e7e-4b0c-a593-55dd7bbf9e27" />
<img width="328" alt="image" src="https://github.com/user-attachments/assets/8129a613-bbde-466b-b252-7d2e7d74ed53" />

<br/>

## 🔧 앞으로의 작업

- pageWrapper theme으로 분리

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #421

## 💬 Comments

글 작성하기 컴포넌트 맡으신 분이 반응형으로 작업하실 거 같아서 변경 안했습니다!