### PR TITLE
Feat/#435/주변활동찾기

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tinymce/tinymce-react": "^5.1.1",
     "@types/tinymce": "^4.6.9",
     "axios": "^1.7.7",
+    "framer-motion": "^11.16.1",
     "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",
     "msw": "^2.6.5",

--- a/src/features/find-nearby-activity-map/indexCss.ts
+++ b/src/features/find-nearby-activity-map/indexCss.ts
@@ -19,6 +19,16 @@ export const LocationButtonBox = styled.div`
   align-items: center;
   justify-content: space-between;
   width: 40%;
+
+  @media (max-width: 1000px) {
+    bottom: 100px;
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    justify-content: center;
+    width: 100%;
+    gap: 1rem;
+  }
 `;
 
 export const MyLocationButton = styled.button`
@@ -33,6 +43,16 @@ export const MyLocationButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  @media (max-width: 1000px) {
+    width: 46px;
+    height: 46px;
+
+    & > img {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
 `;
 
 export const NearbyButton = styled(Button)`
@@ -54,6 +74,13 @@ export const NearbyButton = styled(Button)`
     color: ${theme.pointColor.clicked};
     border: 1px solid ${theme.pointColor.clicked};
     background-color: #d9e8fa;
+  }
+
+  @media (max-width: 1000px) {
+    width: 220px;
+    height: 44px;
+    border-radius: 18px;
+    font-size: ${theme.fontSize.eighthSize};
   }
 `;
 

--- a/src/features/find-nearby-activity-search/indexCss.ts
+++ b/src/features/find-nearby-activity-search/indexCss.ts
@@ -7,6 +7,12 @@ export const SearchBox = styled.div`
   width: 90%;
   height: 100vh;
   padding: 1rem;
+
+  @media (max-width: 1000px) {
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+  }
 `;
 
 export const ScrollSection = styled.div`
@@ -43,6 +49,10 @@ export const SearchBarComponent = styled.div`
   padding: 17px 0 25px 0;
   display: flex;
   gap: 5px;
+
+  @media (max-width: 1000px) {
+    width: 100%;
+  }
 `;
 
 export const Wrapper = styled.ul`

--- a/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/BottomSheet.tsx
+++ b/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/BottomSheet.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
+
+import Header from './Header';
+import { BOTTOM_SHEET_HEIGHT } from './BottomSheetOption';
+import useBottomSheet from './logic/useBottomSheet';
+
+interface BottomSheetProps {
+  children: ReactNode;
+}
+
+const Wrapper = styled(motion.div)`
+  display: flex;
+  flex-direction: column;
+
+  position: fixed;
+  z-index: 999;
+  top: calc(100% - 90px);
+  left: 0;
+  right: 0;
+
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.6);
+  height: ${BOTTOM_SHEET_HEIGHT}px;
+
+  background-color: #f9f9f9;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+
+  transition: transform 650ms ease-out;
+`;
+
+const BottomSheetContent = styled.div`
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+`;
+
+function BottomSheet({ children }: BottomSheetProps) {
+  const { sheet, content, toggleBottomSheetAtWeb } = useBottomSheet();
+
+  return (
+    <Wrapper ref={sheet}>
+      <Header className="bottom-sheet-handle" onClick={toggleBottomSheetAtWeb} />
+      <BottomSheetContent ref={content}>{children}</BottomSheetContent>
+    </Wrapper>
+  );
+}
+
+export default BottomSheet;

--- a/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/BottomSheetOption.ts
+++ b/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/BottomSheetOption.ts
@@ -1,0 +1,3 @@
+export const MIN_Y = window.innerHeight * 0.1; // 화면 높이의 10%를 여백으로
+export const MAX_Y = window.innerHeight - 160;
+export const BOTTOM_SHEET_HEIGHT = window.innerHeight - MIN_Y;

--- a/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/Header.tsx
+++ b/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/Header.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  height: 24x;
+  border-top-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+  position: relative;
+  padding: 12px 0 4px 0;
+  cursor: pointer;
+`;
+
+const Handle = styled.div`
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background-color: #dee2e6;
+  margin: auto;
+`;
+
+interface HeaderProps {
+  onClick: () => void;
+  className?: string;
+}
+
+const Header = ({ onClick, className }: HeaderProps) => {
+  return (
+    <Wrapper className={className} onClick={onClick}>
+      <Handle />
+    </Wrapper>
+  );
+};
+
+export default Header;

--- a/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/logic/useBottomSheet.tsx
+++ b/src/pages/find-nearby-activitiy-page/_components/bottom-sheet/logic/useBottomSheet.tsx
@@ -1,0 +1,180 @@
+import { useRef, useEffect, useState } from 'react';
+import { MAX_Y, MIN_Y } from '../BottomSheetOption';
+
+// !! 주석으로 설명 달아놓을 건데 지우지 말아주세요!!
+interface BottomSheetMetrics {
+  // 터치 시작 시의 상태를 기록
+  touchStart: {
+    sheetY: number; // 사용자가 touchStart 시전에 BottomSheet의 y좌표
+    touchY: number; // 사용자가 touchStart 시점에 터치한 화면의 y좌표
+  };
+  // 터치 도중의 움직임 방향과 이전 상태 추적적
+  touchMove: {
+    prevTouchY?: number; // 직전 touchmove의 터치 y좌표
+    movingDirection: 'none' | 'down' | 'up'; // 사용자가 현재 터치를 통해 BottomSheet를 이동시키는 방향
+  };
+  // 콘텐츠 영역에서 터치가 시작됐는지 판단해 바텀 시트의 움직임 가능 여부 결정
+  isContentAreaTouched: boolean; // 콘텐츠 영역에서 터치가 발생했는지 여부
+}
+
+export default function useBottomSheet() {
+  // BottomSheet와 Content를 참조하기 위한 ref
+  const sheet = useRef<HTMLDivElement>(null); // 바텀 시트 자체를 참조
+  const content = useRef<HTMLDivElement>(null); // 바텀 시트의 내부 콘텐츠를 참조
+  const [isWebBottomSheet, setIsWebBottomSheet] = useState(false); // 웹에서는 터치 이벤트 적용 안되므로 따로 상태 관리
+
+  // user가 바텀시트를 터치하고 움직이는 동안의 상태를 관리하는 객체
+  const metrics = useRef<BottomSheetMetrics>({
+    touchStart: {
+      sheetY: 0,
+      touchY: 0
+    },
+    touchMove: {
+      prevTouchY: 0,
+      movingDirection: 'none'
+    },
+    isContentAreaTouched: false
+  });
+
+  // 사용자가 BottomSheet를 움직일 수 있는지 판단하는 함수
+  const canUserMoveBottomSheet = () => {
+    const { touchMove, isContentAreaTouched } = metrics.current;
+
+    if (!isContentAreaTouched) {
+      // 콘텐츠가 아닌 곳에서 터치했으면 이동 가능
+      return true;
+    }
+
+    if (sheet.current!.getBoundingClientRect().y !== MIN_Y) {
+      // 바텀 시트가 이미 열린 상태라면 이동 가능
+      return true;
+    }
+
+    if (touchMove.movingDirection === 'down') {
+      // 콘텐츠가 스크롤 최상단이면 아래로 이동 가능
+      return content.current!.scrollTop <= 0;
+    }
+    return false;
+  };
+
+  // 터치 시작 시 실행되는 이벤트 핸들러
+  const handleTouchStart = (e: TouchEvent) => {
+    const { touchStart } = metrics.current;
+    touchStart.sheetY = sheet.current!.getBoundingClientRect().y; // 터치 시작 시 BottomSheet의 Y 좌표
+    touchStart.touchY = e.touches[0].clientY; // 터치 시작 시 터치한 화면의 Y 좌표
+  };
+
+  // 터치 이동 중 실행되는 이벤트 핸들러
+  const handleTouchMove = (e: TouchEvent) => {
+    const { touchStart, touchMove } = metrics.current;
+    const currentTouch = e.touches[0];
+
+    if (touchMove.prevTouchY === undefined) {
+      // 처음 터치 시 prevTouchY를 초기화
+      touchMove.prevTouchY = touchStart.touchY;
+    }
+
+    if (touchMove.prevTouchY === 0) {
+      // 맨 처음 앱 시작하고 시작시
+      touchMove.prevTouchY = touchStart.touchY;
+    }
+
+    // 터치 방향 확인
+    if (touchMove.prevTouchY < currentTouch.clientY) {
+      touchMove.movingDirection = 'down'; // 아래 방향
+    }
+
+    if (touchMove.prevTouchY > currentTouch.clientY) {
+      touchMove.movingDirection = 'up'; // 위 방향
+    }
+
+    if (canUserMoveBottomSheet()) {
+      // BottomSheet를 움직일 수 있는 상태일 경우
+      e.preventDefault(); // 기본 스크롤 방지
+
+      const touchOffset = currentTouch.clientY - touchStart.touchY; // 터치 이동 거리
+      let nextSheetY = touchStart.sheetY + touchOffset; // 새로운 BottomSheet의 Y 좌표 계산
+
+      // Y 좌표가 최소/최대값을 벗어나지 않도록 제한
+      if (nextSheetY <= MIN_Y) {
+        nextSheetY = MIN_Y;
+      }
+
+      if (nextSheetY >= MAX_Y) {
+        nextSheetY = MAX_Y;
+      }
+
+      // BottomSheet의 위치를 업데이트
+      sheet.current!.style.setProperty('transform', `translateY(${nextSheetY - MAX_Y}px)`); //바닥 만큼은 빼야쥬...
+    } else {
+      // 사용자가 BottomSheet를 움직일 수 없는 상태일 경우
+      document.body.style.overflowY = 'hidden'; // 화면 스크롤 비활성화
+    }
+  };
+
+  // 터치 종료 시 실행되는 이벤트 핸들러
+  const handleTouchEnd = () => {
+    document.body.style.overflowY = 'auto'; // 화면 스크롤 활성화
+    const { touchMove } = metrics.current;
+
+    // Snap Animation: BottomSheet 위치를 고정
+    const currentSheetY = sheet.current!.getBoundingClientRect().y;
+
+    if (currentSheetY !== MIN_Y) {
+      if (touchMove.movingDirection === 'down') {
+        // 아래로 이동했을 경우 BottomSheet를 MAX_Y 위치로 이동
+        sheet.current!.style.setProperty('transform', 'translateY(0)');
+      }
+
+      if (touchMove.movingDirection === 'up') {
+        // 위로 이동했을 경우 BottomSheet를 MIN_Y 위치로 이동
+        sheet.current!.style.setProperty('transform', `translateY(${MIN_Y - MAX_Y}px)`);
+      }
+    }
+
+    // metrics 객체 초기화
+    metrics.current = {
+      touchStart: {
+        sheetY: 0,
+        touchY: 0
+      },
+      touchMove: {
+        prevTouchY: 0,
+        movingDirection: 'none'
+      },
+      isContentAreaTouched: false
+    };
+  };
+
+  // 웹에서는 클릭으로 바텀시트 토클할 수 있도록 핸들러 추가
+  const toggleBottomSheetAtWeb = () => {
+    if (sheet.current) {
+      if (!isWebBottomSheet) {
+        // 열기
+        sheet.current.style.setProperty('transform', `translateY(${MIN_Y - MAX_Y}px)`);
+      } else {
+        // 닫기
+        sheet.current.style.setProperty('transform', 'translateY(0)');
+      }
+      setIsWebBottomSheet(!isWebBottomSheet);
+    }
+  };
+
+  // 컴포넌트가 마운트되었을 때 이벤트 리스너 추가 및 언마운트 시 제거
+  useEffect(() => {
+    if (!sheet.current || !content.current) return;
+
+    // 터치이벤트 -> 모바일 환경에서
+    sheet.current!.addEventListener('touchstart', handleTouchStart);
+    sheet.current!.addEventListener('touchmove', handleTouchMove);
+    sheet.current!.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      sheet.current?.removeEventListener('touchstart', handleTouchStart);
+      sheet.current?.removeEventListener('touchmove', handleTouchMove);
+      sheet.current?.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, []);
+
+  return { sheet, content, toggleBottomSheetAtWeb };
+}

--- a/src/pages/find-nearby-activitiy-page/index.tsx
+++ b/src/pages/find-nearby-activitiy-page/index.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { MapWrapper, PageWrapper, SearchContainer } from './indexCss';
+import { MapWrapper, PageWrapper } from './indexCss';
 import FindNearByActivityMap from '@/features/find-nearby-activity-map';
 import FindNearByActivitySearch from '@/features/find-nearby-activity-search';
 import type { Activity } from '@/shared/types/location/nearbyLocation';
@@ -62,9 +62,10 @@ const FindNearByActivityPage = () => {
             <FindNearByActivitySearch activities={activities} isLoading={isLoading} onSearch={handleSearch} />
           </BottomSheet>
         ) : (
-          <SearchContainer>
-            <FindNearByActivitySearch activities={activities} isLoading={isLoading} onSearch={handleSearch} />
-          </SearchContainer>
+          // <SearchContainer>
+          //   <FindNearByActivitySearch activities={activities} isLoading={isLoading} onSearch={handleSearch} />
+          // </SearchContainer>
+          <FindNearByActivitySearch activities={activities} isLoading={isLoading} onSearch={handleSearch} />
         )}
 
         <FindNearByActivityMap

--- a/src/pages/find-nearby-activitiy-page/index.tsx
+++ b/src/pages/find-nearby-activitiy-page/index.tsx
@@ -1,14 +1,30 @@
 import { useNavigate } from 'react-router-dom';
-import { MapWrapper, PageWrapper } from './indexCss';
+import { MapWrapper, PageWrapper, SearchContainer } from './indexCss';
 import FindNearByActivityMap from '@/features/find-nearby-activity-map';
 import FindNearByActivitySearch from '@/features/find-nearby-activity-search';
 import type { Activity } from '@/shared/types/location/nearbyLocation';
 import UseMapLocation from './logic/useMapLocation';
 import useNearbySearch from './logic/useNearbySearch';
 import useMapControl from './logic/useMapControl';
+import { useEffect, useState } from 'react';
+import BottomSheet from './_components/bottom-sheet/BottomSheet';
 
 const FindNearByActivityPage = () => {
+  const [isMobile, setIsMobile] = useState(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 1000);
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   const { center, setCenter, updateCenter, setUpdateCenter, position, mapLevel, setMapLevel, setCenterToMyPosition } =
     UseMapLocation({
       initialCenter: {
@@ -41,7 +57,16 @@ const FindNearByActivityPage = () => {
   return (
     <PageWrapper>
       <MapWrapper>
-        <FindNearByActivitySearch activities={activities} isLoading={isLoading} onSearch={handleSearch} />
+        {isMobile ? (
+          <BottomSheet>
+            <FindNearByActivitySearch activities={activities} isLoading={isLoading} onSearch={handleSearch} />
+          </BottomSheet>
+        ) : (
+          <SearchContainer>
+            <FindNearByActivitySearch activities={activities} isLoading={isLoading} onSearch={handleSearch} />
+          </SearchContainer>
+        )}
+
         <FindNearByActivityMap
           center={center}
           position={position}

--- a/src/pages/find-nearby-activitiy-page/indexCss.ts
+++ b/src/pages/find-nearby-activitiy-page/indexCss.ts
@@ -15,3 +15,10 @@ export const MapWrapper = styled.div`
   display: flex;
   width: 100%;
 `;
+
+export const SearchContainer = styled.div`
+  width: 400px;
+  background-color: white;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+  z-index: 1;
+`;

--- a/src/pages/find-nearby-activitiy-page/indexCss.ts
+++ b/src/pages/find-nearby-activitiy-page/indexCss.ts
@@ -16,9 +16,9 @@ export const MapWrapper = styled.div`
   width: 100%;
 `;
 
-export const SearchContainer = styled.div`
-  width: 400px;
-  background-color: white;
-  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
-  z-index: 1;
-`;
+// export const SearchContainer = styled.div`
+//   width: 35%;
+//   background-color: white;
+//   box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+//   z-index: 1;
+// `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,6 +1870,15 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+framer-motion@^11.16.1:
+  version "11.16.1"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.16.1.tgz#3768ba04acbe51bdba599dc8a10db7b9737cc020"
+  integrity sha512-xsjhEUSWHn39g334PpBTH+QissgEJVJkpRGS/4QUyMSmoJSNxA+7FTuq61s+OXPMS4muu5k9Y6r7GpcNKhd1xA==
+  dependencies:
+    motion-dom "^11.16.1"
+    motion-utils "^11.16.0"
+    tslib "^2.4.0"
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -2394,6 +2403,18 @@ minimatch@^9.0.4:
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
+
+motion-dom@^11.16.1:
+  version "11.16.1"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-11.16.1.tgz#ce1057bbd12bece8eb1cd42f99d64013b24cf949"
+  integrity sha512-XVNf3iCfZn9OHPZYJQy5YXXLn0NuPNvtT3YCat89oAnr4D88Cr52KqFgKa8dWElBK8uIoQhpJMJEG+dyniYycQ==
+  dependencies:
+    motion-utils "^11.16.0"
+
+motion-utils@^11.16.0:
+  version "11.16.0"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-11.16.0.tgz#e75865442278be49e411ca9105c9139edc572811"
+  integrity sha512-ngdWPjg31rD4WGXFi0eZ00DQQqKKu04QExyv/ymlC+3k+WIgYVFbt6gS5JsFPbJODTF/r8XiE/X+SsoT9c0ocw==
 
 ms@^2.1.3:
   version "2.1.3"
@@ -3112,6 +3133,11 @@ tslib@2.6.2, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## 🔎 작업 내용

- 웹에서는 클릭해서 토클로 바텀 시트 여닫고, 모바일일 때는 터치 이벤트로 바텀시트 끌어올리고 닫는 기능 구현했습니다.
-
<img width="674" alt="image" src="https://github.com/user-attachments/assets/af4b9ee6-f1a5-4b15-8d7f-df20544ca6d6" />

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #435

## 💬 Comments

구글링해서 거의 복붙해서 쓴 코드라 차차 이해하면서 리팩토링 하겠습니다.. 일단 이해한 만큼 주석 달아놓았으니 확인해보시면 될 것 같습니당.!