### PR TITLE
📈 [#488] Refactor: 로그아웃시 window.location.href='/main'으로 새로고침하며 메인 페이지…

### DIFF
--- a/src/layout/header/Header.tsx
+++ b/src/layout/header/Header.tsx
@@ -136,7 +136,7 @@ export default function Header() {
                 try {
                   clearLoginInfo();
                   await commonLogout();
-                  window.location.reload();
+                  window.location.href = '/main';
                 } catch (error) {
                   console.error('로그아웃 실패:', error);
                 }


### PR DESCRIPTION
…로 이동하도록 변경

## 🔎 작업 내용
- 정산하기 모달 반응형 브랜치 파둬서 거기에 하려 했는데 아직 정산하기 모달이 안열려서 그냥 브랜치 하나 새로 팠습니다..ㅎㅎ
- window.location.reload()로 되어 있는 부분을 window.location.href="/main"으로 변경하여 로그아웃하면 http 요청을 보내 새로고침이 되며 메인 페이지로 이동하게 됩니다.
- 처음엔 useNavigate를 사용하려 했으나 react-router-dom의 useNavigate는 react 라우팅 내에서 작동하기 때문에 메모리가 초기화되지 않고 남아있을 수 있다고 합니다. 그래서 새로고침을 하여 메모리를 완전히 초기화 시키는 것이 좋다고 생각이 들어서 window.location.href를 사용했습니당
<img width="532" alt="image" src="https://github.com/user-attachments/assets/93f83a17-c61b-4b16-993c-1e2013ed72e2" />

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #488