### PR TITLE
🐛fix:모집글 상태라벨 조건처리

### DIFF
--- a/src/pages/aidrq-detail-page/ui/title/index.tsx
+++ b/src/pages/aidrq-detail-page/ui/title/index.tsx
@@ -19,7 +19,10 @@ const Title: React.FC<AidRqDetailCenterProfileProps> = ({ data }) => {
       </LabelBox>
       <TitleBox>
         <h2>{data.title}</h2>
-        <AidRqStateLabel state="모집중"></AidRqStateLabel>
+        <AidRqStateLabel
+          state={
+            data.recruit_status === 'RECRUITING' ? '모집중' : data.recruit_status === 'CLOSED' ? '모집완료' : '종료'
+          }></AidRqStateLabel>
       </TitleBox>
       <CreatedAt>등록 일자 : {formatDate(data.created_at)}</CreatedAt>
     </Wrapper>


### PR DESCRIPTION
## 🔎 작업 내용

- 모집글 상태를 보여주는 라벨이 항상 '모집중'으로 되어있던 것 수정.

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->