### PR TITLE
🐛fix:오류개선 및 글자수제한

### DIFF
--- a/src/features/message-create-modal/logic/useSendMail.ts
+++ b/src/features/message-create-modal/logic/useSendMail.ts
@@ -28,6 +28,7 @@ export const useSendMail = ({ user_id, setIsModalOpen }: UseSendEmailProps): Use
   const checkErr = () => {
     if (mailTitle === '') setErrMsg('제목이 비어있습니다');
     else if (mailContent === '') setErrMsg('내용이 비어있습니다');
+    else if (mailContent.length > 500) setErrMsg('쪽지 내용은 500자 이하로 작성해주세요.');
     else setErrMsg('');
   };
   const checkTitle = (txt: string) => {

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import Header from './header/Header';
 import Footer from './footer/Footer';
 import { useEffect } from 'react';
-import { Wrapper } from './LayoutCss';
+import { Main, Wrapper } from './LayoutCss';
 
 export default function Layout() {
   const location = useLocation();
@@ -14,7 +14,9 @@ export default function Layout() {
   return (
     <Wrapper>
       <Header />
-      <Outlet />
+      <Main>
+        <Outlet />
+      </Main>
       <Footer />
     </Wrapper>
   );

--- a/src/layout/LayoutCss.ts
+++ b/src/layout/LayoutCss.ts
@@ -1,7 +1,13 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.body`
+export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+`;
+
+export const Main = styled.main`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 `;

--- a/src/layout/header/Header.tsx
+++ b/src/layout/header/Header.tsx
@@ -134,8 +134,8 @@ export default function Header() {
             <LogoutBtn
               onClick={async () => {
                 try {
-                  clearLoginInfo();
                   await commonLogout();
+                  clearLoginInfo();
                   window.location.href = '/main';
                 } catch (error) {
                   console.error('로그아웃 실패:', error);

--- a/src/pages/aidrq-create-page/logic/validateVolunteerData.ts
+++ b/src/pages/aidrq-create-page/logic/validateVolunteerData.ts
@@ -32,6 +32,10 @@ export const validateVolunteerData = (data: VolunteerType) => {
     errors.push('활동 설명을 입력해주세요.');
   }
 
+  if (data.content.length > 1000) {
+    errors.push('활동 설명은 1000자 이하로 작성해주세요.');
+  }
+
   // 날짜 검사
   if (data.volunteer_start_date_time && data.volunteer_end_date_time) {
     const startDate = new Date(data.volunteer_start_date_time);

--- a/src/pages/aidrq-modify-page/logic/validateVolunteerData.ts
+++ b/src/pages/aidrq-modify-page/logic/validateVolunteerData.ts
@@ -38,6 +38,10 @@ export const validateVolunteerData = (data: ChangedRegularData, createdAt: strin
     errors.push('활동 설명을 입력해주세요.');
   }
 
+  if (data.content.length > 1000) {
+    errors.push('활동 설명은 1000자 이하로 입력해주세요.');
+  }
+
   // 날짜 검사
   if (data.volunteer_start_date_time && data.volunteer_end_date_time) {
     const startDate = new Date(data.volunteer_start_date_time);


### PR DESCRIPTION
## 🔎 작업 내용

- 모집글작성/수정/쪽지작성에 글자수제한 유효성검사 추가
- 로그아웃 시 오류부분 개선 (set함수와 api함수의 순서가 맞지않아서 오류가 발생)
- Layout.tsx에서 나는 오류개선 (Wrapper컴포넌트의 스타일컴포넌트를 body로 줘서 났던 오류)
- Footer하단에 붙어있지 않는 오류개선 (flex:1 미스)

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 리뷰, 마이페이지, 커뮤니티는 추가적으로 유효성검사 필요

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->