### PR TITLE
🐛fix:사이트재접 시 오류 개선

### DIFF
--- a/src/pages/main-page/MainPage.tsx
+++ b/src/pages/main-page/MainPage.tsx
@@ -17,6 +17,7 @@ export default function MainPage() {
 
   const loginType = useLoginStore((state) => state.loginType);
   const setLoginInfo = useLoginStore((state) => state.setLoginInfo);
+  const clearLoginIngo = useLoginStore((state) => state.clearLoginInfo);
   const setCenterIds = useInterestStore((state) => state.setCenterIds);
 
   //단기토큰 받는거로 바뀌면, 해당 단기토큰으로 ACCESS토큰 받아오는 useEffect하나 더 필요 (쿠키에서 꺼내서 보내는거로)
@@ -27,7 +28,10 @@ export default function MainPage() {
   useEffect(() => {
     const getLoginInfo = () => {
       try {
-        if (!token) return;
+        if (!token) {
+          clearLoginIngo();
+          return;
+        }
 
         // Bearer 제거
         const actualToken = token.replace('Bearer ', '');


### PR DESCRIPTION
## 🔎 작업 내용

사이트를 로그아웃하지 않은 상태로 처음 들어왔을 때, 로그인 되어있는 오류
로그아웃을 누르면 zustand는 사라지지만 로그아웃 api는 오류코드가 발생함

main에 들어왔을 때, token이 없는 경우, 자동으로 logout 시키는 것으로 변경

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->