### PR TITLE
Feat/#511/html to markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.7.7",
     "event-source-polyfill": "^1.0.31",
     "framer-motion": "^11.16.1",
+    "html-react-parser": "^5.2.2",
     "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",
     "msw": "^2.6.5",

--- a/src/components/aidreq-list-Item/ui/top/index.tsx
+++ b/src/components/aidreq-list-Item/ui/top/index.tsx
@@ -1,3 +1,4 @@
+import parse from 'html-react-parser';
 import AidRqCategoryLabel from '@/components/label/AidRqCategoryLabel';
 import { Wrapper, LabelContainer, Title, Text, Center } from './indexCss';
 import AidRqCertifiedLabel from '@/components/label/AidRqCertifiedLabel';
@@ -20,7 +21,7 @@ const Top = ({ title, content, center, category, admitted }: TopProps) => {
         {admitted && <AidRqCertifiedLabel></AidRqCertifiedLabel>}
       </LabelContainer>
       <Title>{title}</Title>
-      <Text>{content}</Text>
+      <Text>{parse(content)}</Text>
       <Center>{center?.name}</Center>
     </Wrapper>
   );

--- a/src/components/content-viewer/index.tsx
+++ b/src/components/content-viewer/index.tsx
@@ -1,0 +1,12 @@
+import parse from 'html-react-parser';
+import { Container } from './indexCss';
+
+interface ContentViewerProps {
+  content: string;
+}
+
+const ContentViewer = ({ content }: ContentViewerProps) => {
+  return <Container>{parse(content)}</Container>;
+};
+
+export default ContentViewer;

--- a/src/components/content-viewer/indexCss.ts
+++ b/src/components/content-viewer/indexCss.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+
+  img {
+    max-width: 100%;
+  }
+`;

--- a/src/features/aidreq-detail-admin-content/_components/text-content/index.tsx
+++ b/src/features/aidreq-detail-admin-content/_components/text-content/index.tsx
@@ -1,3 +1,4 @@
+import parse from 'html-react-parser';
 import { Content, ExpectedRecruit, TextContentContainer } from './indexCss';
 
 interface TextContentProps {
@@ -7,7 +8,7 @@ interface TextContentProps {
 const TextContent = ({ content, recruitmentCount }: TextContentProps) => {
   return (
     <TextContentContainer>
-      <Content>{content}</Content>
+      <Content>{parse(content)}</Content>
       <ExpectedRecruit>예상 모집 인원: {recruitmentCount}명</ExpectedRecruit>
     </TextContentContainer>
   );

--- a/src/features/communitiy-detail-content-box/index.tsx
+++ b/src/features/communitiy-detail-content-box/index.tsx
@@ -59,7 +59,7 @@ const CommunityDetailContentBox = ({ content_id }: { content_id: number }) => {
           <CommunityImage src={detailData.image_url} alt="detailData.image_url" />
         </CommunityImageContainer>
       )}
-      <EditorContent dangerouslySetInnerHTML={{ __html: detailData.content }} className="content" />; ;
+      <EditorContent dangerouslySetInnerHTML={{ __html: detailData.content }} className="content" />
       <div className="btnWrap">
         {isMyContent ? (
           <EditDeleteBtnCon>

--- a/src/features/communitiy-detail-content-box/index.tsx
+++ b/src/features/communitiy-detail-content-box/index.tsx
@@ -1,3 +1,4 @@
+import parse from 'html-react-parser';
 import { useDeleteCommunity } from '@/store/queries/community-create-common-query/useControlCommunity';
 import {
   ApplyButton,
@@ -59,7 +60,10 @@ const CommunityDetailContentBox = ({ content_id }: { content_id: number }) => {
           <CommunityImage src={detailData.image_url} alt="detailData.image_url" />
         </CommunityImageContainer>
       )}
-      <EditorContent dangerouslySetInnerHTML={{ __html: detailData.content }} className="content" />
+      {/* 
+      일단 주석처리
+      <EditorContent dangerouslySetInnerHTML={{ __html: detailData.content }} className="content" /> */}
+      <EditorContent className="content">{parse(detailData.content)}</EditorContent>
       <div className="btnWrap">
         {isMyContent ? (
           <EditDeleteBtnCon>

--- a/src/pages/aidrq-detail-page/ui/text-content/index.tsx
+++ b/src/pages/aidrq-detail-page/ui/text-content/index.tsx
@@ -1,3 +1,4 @@
+import parse from 'html-react-parser';
 import { RecruitCount, Text, Wrapper } from './indexCss';
 import { AidRqDetailType } from '@/shared/types/aidrq-detail/aidrqDetailType';
 
@@ -9,7 +10,7 @@ const TextContent: React.FC<AidRqDetailCenterProfileProps> = ({ data }) => {
   return (
     <Wrapper>
       <div>
-        <Text>{data.content}</Text>
+        <Text>{parse(data.content)}</Text>
       </div>
       <RecruitCount>예상 모집 인원 : {data.recruitment_count}명</RecruitCount>
     </Wrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,10 +1486,50 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@5.0.3, domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.0.tgz#09c9e29cb79b0a6459a9b9db9efb418ac5bb8e51"
+  integrity sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2062,6 +2102,34 @@ hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
+html-dom-parser@5.0.13:
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-5.0.13.tgz#36b25b3ad05dc71741e9cd200ff276cdf8e3831d"
+  integrity sha512-B7JonBuAfG32I7fDouUQEogBrz3jK9gAuN1r1AaXpED6dIhtg/JwiSRhjGL7aOJwRz3HU4efowCjQBaoXiREqg==
+  dependencies:
+    domhandler "5.0.3"
+    htmlparser2 "10.0.0"
+
+html-react-parser@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-5.2.2.tgz#a4159c14f08c06280ff793ce35f872c2283227cb"
+  integrity sha512-yA5012CJGSFWYZsgYzfr6HXJgDap38/AEP4ra8Cw+WHIi2ZRDXRX/QVYdumRf1P8zKyScKd6YOrWYvVEiPfGKg==
+  dependencies:
+    domhandler "5.0.3"
+    html-dom-parser "5.0.13"
+    react-property "2.0.2"
+    style-to-js "1.1.16"
+
+htmlparser2@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.0.0.tgz#77ad249037b66bf8cc99c6e286ef73b83aeb621d"
+  integrity sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.1"
+    entities "^6.0.0"
+
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
@@ -2079,6 +2147,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inline-style-parser@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.2.4.tgz#f4af5fe72e612839fcd453d989a586566d695f22"
+  integrity sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==
 
 internal-slot@^1.0.7:
   version "1.0.7"
@@ -2749,6 +2822,11 @@ react-kakao-maps-sdk@^1.1.27:
     "@babel/runtime" "^7.22.15"
     kakao.maps.d.ts "^0.1.39"
 
+react-property@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.2.tgz#d5ac9e244cef564880a610bc8d868bd6f60fdda6"
+  integrity sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==
+
 react-router-dom@^6.28.0:
   version "6.28.0"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz"
@@ -3072,6 +3150,20 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+style-to-js@1.1.16:
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.16.tgz#e6bd6cd29e250bcf8fa5e6591d07ced7575dbe7a"
+  integrity sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==
+  dependencies:
+    style-to-object "1.0.8"
+
+style-to-object@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.8.tgz#67a29bca47eaa587db18118d68f9d95955e81292"
+  integrity sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==
+  dependencies:
+    inline-style-parser "0.2.4"
 
 styled-components@^6.1.13:
   version "6.1.13"


### PR DESCRIPTION
## 🔎 작업 내용

- dangerouslySetInnerHTML도 html 태그들을 변환하여 보여주는데에 하나의 방법이지만 이 경우에 이름에도 나와 있는 것처럼 직접적인 HTML 삽입을 하기 때문에 문자열을 그대로 HTML로 파싱하여 DOM에 삽입한다고 합니다.
이는 스크립트 태그나 악성 코드가 포함된 HTML도 그대로 실행될 수 있어서 XSS(Cross Site Scripting)에 취약하다고 합니다. 
- 그래서 htm-react-parser라는 라이브러리를 설치해 아래 코드와 같이 사용해주었습니다.
이 라이브러리는단순히 HTML을 React 컴포넌트로 변환만 해주고, 변환 과정에서 여러 보안 처리를 같이 수행되어 위의 방법 보다 XSS 공격에 안전하다고 합니다!
```
import parse from 'html-react-parser';
import { Content, ExpectedRecruit, TextContentContainer } from './indexCss';

interface TextContentProps {
  content: string;
  recruitmentCount: number;
}
const TextContent = ({ content, recruitmentCount }: TextContentProps) => {
  return (
    <TextContentContainer>
      <Content>{parse(content)}</Content>
      <ExpectedRecruit>예상 모집 인원: {recruitmentCount}명</ExpectedRecruit>
    </TextContentContainer>
  );
};

export default TextContent;
```

  <br/>

### 작업 결과 (관련 스크린샷)

<img width="773" alt="image" src="https://github.com/user-attachments/assets/223bb0de-e3da-4109-b2b5-29e977af2827" />

<br/>

## 🔧 앞으로의 작업

- 다들 새로 브랜치 생성하시거나 pull 하실 때 yarn install 한번씩 해주세요!
- 로그인 이슈 해결되면 텍스트 에디터의 다양한 마크다운 (h1, 이텔릭, b 태그 등) 사용해서 잘 렌더링 되는지 확인
- 이미지태그 잘 반영돼서 이미지 뜨는지 백엔드 완료 후 확인

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #511
