### PR TITLE
Refactor/#523/모집글작성json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.60.2",
     "@tanstack/react-query-devtools": "^5.60.5",
     "@tinymce/tinymce-react": "^5.1.1",
+    "@types/sanitize-html": "^2.13.0",
     "@types/tinymce": "^4.6.9",
     "axios": "^1.7.7",
     "event-source-polyfill": "^1.0.31",
@@ -33,6 +34,7 @@
     "react-kakao-maps-sdk": "^1.1.27",
     "react-router-dom": "^6.28.0",
     "react-toastify": "^10.0.6",
+    "sanitize-html": "^2.14.0",
     "styled-components": "^6.1.13",
     "styled-reset": "^4.5.2",
     "zustand": "^5.0.1"

--- a/src/components/aidreq-list-Item/ui/top/index.tsx
+++ b/src/components/aidreq-list-Item/ui/top/index.tsx
@@ -1,3 +1,4 @@
+import sanitizeHtml from 'sanitize-html';
 import parse from 'html-react-parser';
 import AidRqCategoryLabel from '@/components/label/AidRqCategoryLabel';
 import { Wrapper, LabelContainer, Title, Text, Center } from './indexCss';
@@ -14,6 +15,23 @@ interface TopProps {
 }
 
 const Top = ({ title, content, center, category, admitted }: TopProps) => {
+  const sanitizedContent = sanitizeHtml(content, {
+    allowedTags: ['p', 'img', 'br', 'b', 'strong', 'em', 'ul', 'ol', 'li', 'a', 'span'],
+    allowedAttributes: {
+      '*': ['style'], // 모든 태그에 style 속성 허용
+      a: ['href', 'target'],
+      img: ['src', 'alt']
+    },
+    allowedStyles: {
+      '*': {
+        color: [/.*/],
+        'background-color': [/.*/],
+        'font-size': [/.*/],
+        'text-align': [/.*/]
+      }
+    }
+  });
+
   return (
     <Wrapper>
       <LabelContainer>
@@ -21,7 +39,7 @@ const Top = ({ title, content, center, category, admitted }: TopProps) => {
         {admitted && <AidRqCertifiedLabel></AidRqCertifiedLabel>}
       </LabelContainer>
       <Title>{title}</Title>
-      <Text>{parse(content)}</Text>
+      <Text>{parse(sanitizedContent)}</Text>
       <Center>{center?.name}</Center>
     </Wrapper>
   );

--- a/src/components/aidreq-list-Item/ui/top/indexCss.ts
+++ b/src/components/aidreq-list-Item/ui/top/indexCss.ts
@@ -27,6 +27,39 @@ export const Text = styled.p`
   color: #535353;
   height: 28px;
   overflow: hidden;
+
+  h1 {
+    font-size: 2em;
+    font-weight: bold;
+    margin-bottom: 1em;
+  }
+
+  h2 {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 0.8em;
+  }
+
+  h3 {
+    font-size: 1.17em;
+    font-weight: bold;
+    margin-bottom: 0.6em;
+  }
+
+  ul,
+  ol {
+    margin: 1em 0;
+    padding-left: 2em;
+  }
+
+  li {
+    list-style: disc;
+    margin: 0.5em 0;
+  }
+
+  strong {
+    font-weight: bold;
+  }
 `;
 
 export const Center = styled.p`

--- a/src/features/aidreq-detail-admin-content/_components/text-content/index.tsx
+++ b/src/features/aidreq-detail-admin-content/_components/text-content/index.tsx
@@ -1,4 +1,5 @@
 import parse from 'html-react-parser';
+import sanitizeHtml from 'sanitize-html';
 import { Content, ExpectedRecruit, TextContentContainer } from './indexCss';
 
 interface TextContentProps {
@@ -6,9 +7,43 @@ interface TextContentProps {
   recruitmentCount: number;
 }
 const TextContent = ({ content, recruitmentCount }: TextContentProps) => {
+  const sanitizedContent = sanitizeHtml(content, {
+    allowedTags: [
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'p',
+      'img',
+      'br',
+      'b',
+      'strong',
+      'em',
+      'ul',
+      'ol',
+      'li',
+      'a',
+      'span'
+    ],
+    allowedAttributes: {
+      '*': ['style'], // 모든 태그에 style 속성 허용
+      a: ['href', 'target'],
+      img: ['src', 'alt']
+    },
+    allowedStyles: {
+      '*': {
+        color: [/.*/],
+        'background-color': [/.*/],
+        'font-size': [/.*/],
+        'text-align': [/.*/]
+      }
+    }
+  });
   return (
     <TextContentContainer>
-      <Content>{parse(content)}</Content>
+      <Content>{parse(sanitizedContent)}</Content>
       <ExpectedRecruit>예상 모집 인원: {recruitmentCount}명</ExpectedRecruit>
     </TextContentContainer>
   );

--- a/src/features/aidreq-detail-admin-content/_components/text-content/indexCss.ts
+++ b/src/features/aidreq-detail-admin-content/_components/text-content/indexCss.ts
@@ -21,6 +21,39 @@ export const Content = styled.p`
   border-bottom: 1px solid #d1d1d1;
   padding: 0 64px;
 
+  h1 {
+    font-size: 2em;
+    font-weight: bold;
+    margin-bottom: 1em;
+  }
+
+  h2 {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 0.8em;
+  }
+
+  h3 {
+    font-size: 1.17em;
+    font-weight: bold;
+    margin-bottom: 0.6em;
+  }
+
+  ul,
+  ol {
+    margin: 1em 0;
+    padding-left: 2em;
+  }
+
+  li {
+    list-style: disc;
+    margin: 0.5em 0;
+  }
+
+  strong {
+    font-weight: bold;
+  }
+
   @media (max-width: 1000px) {
     padding: 0 25px;
   }

--- a/src/pages/aidrq-detail-page/ui/text-content/index.tsx
+++ b/src/pages/aidrq-detail-page/ui/text-content/index.tsx
@@ -1,4 +1,5 @@
 import parse from 'html-react-parser';
+import sanitizeHtml from 'sanitize-html';
 import { RecruitCount, Text, Wrapper } from './indexCss';
 import { AidRqDetailType } from '@/shared/types/aidrq-detail/aidrqDetailType';
 
@@ -7,10 +8,44 @@ interface AidRqDetailCenterProfileProps {
 }
 
 const TextContent: React.FC<AidRqDetailCenterProfileProps> = ({ data }) => {
+  const sanitizedContent = sanitizeHtml(data.content, {
+    allowedTags: [
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'p',
+      'img',
+      'br',
+      'b',
+      'strong',
+      'em',
+      'ul',
+      'ol',
+      'li',
+      'a',
+      'span'
+    ],
+    allowedAttributes: {
+      '*': ['style'], // 모든 태그에 style 속성 허용
+      a: ['href', 'target'],
+      img: ['src', 'alt']
+    },
+    allowedStyles: {
+      '*': {
+        color: [/.*/],
+        'background-color': [/.*/],
+        'font-size': [/.*/],
+        'text-align': [/.*/]
+      }
+    }
+  });
   return (
     <Wrapper>
       <div>
-        <Text>{parse(data.content)}</Text>
+        <Text>{parse(sanitizedContent)}</Text>
       </div>
       <RecruitCount>예상 모집 인원 : {data.recruitment_count}명</RecruitCount>
     </Wrapper>

--- a/src/pages/aidrq-detail-page/ui/text-content/indexCss.ts
+++ b/src/pages/aidrq-detail-page/ui/text-content/indexCss.ts
@@ -20,6 +20,39 @@ export const Wrapper = styled.div`
 export const Text = styled.p`
   color: #535353;
   line-height: 24px;
+
+  h1 {
+    font-size: 2em;
+    font-weight: bold;
+    margin-bottom: 1em;
+  }
+
+  h2 {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: 0.8em;
+  }
+
+  h3 {
+    font-size: 1.17em;
+    font-weight: bold;
+    margin-bottom: 0.6em;
+  }
+
+  ul,
+  ol {
+    margin: 1em 0;
+    padding-left: 2em;
+  }
+
+  li {
+    list-style: disc;
+    margin: 0.5em 0;
+  }
+
+  strong {
+    font-weight: bold;
+  }
 `;
 
 export const RecruitCount = styled.p`

--- a/src/store/queries/aidreq-control-center-query/useModifyAidRqRegular.ts
+++ b/src/store/queries/aidreq-control-center-query/useModifyAidRqRegular.ts
@@ -3,18 +3,14 @@ import axios from 'axios';
 
 import { RegularData } from '@/shared/types/aidrq-detail/aidrqDetailType';
 
-export const updateRegular = async (id: string, changedRegular: RegularData, imgFile?: File) => {
+export const updateRegular = async (id: string, changedRegular: RegularData) => {
   try {
-    console.log(changedRegular);
-    const formData = new FormData();
-    formData.append('data', JSON.stringify(changedRegular));
-    formData.append('img_file', imgFile || '');
+    // console.log(changedRegular);
+    // const formData = new FormData();
+    // formData.append('data', JSON.stringify(changedRegular));
+    // formData.append('img_file', imgFile || '');
 
-    const response = await axiosInstance.put(`/api/recruit-board/${id}`, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data'
-      }
-    });
+    const response = await axiosInstance.put(`/api/recruit-board/${id}`, changedRegular);
     return response;
   } catch (error) {
     console.log('Full error:', error);

--- a/src/store/queries/aidreq-control-center-query/usePostAidRq.ts
+++ b/src/store/queries/aidreq-control-center-query/usePostAidRq.ts
@@ -5,20 +5,16 @@ import axios from 'axios';
 
 interface PostAidRqParams {
   volunteerData: VolunteerType;
-  imgFile?: File;
+  // imgFile?: File;
 }
 
-const postAidRqFn = async ({ volunteerData, imgFile }: PostAidRqParams) => {
-  const formData = new FormData();
-  formData.append('data', JSON.stringify(volunteerData));
-  formData.append('img_file', imgFile || '');
+const postAidRqFn = async ({ volunteerData }: PostAidRqParams) => {
+  // const formData = new FormData();
+  // formData.append('data', JSON.stringify(volunteerData));
+  // formData.append('img_file', imgFile || '');
 
-  const response = await axiosInstance.post('/api/recruit-board', formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data'
-    }
-  });
-  return response.data;
+  const response = await axiosInstance.post('/api/recruit-board', volunteerData);
+  return response;
 };
 
 export const usePostAidRq = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,13 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/sanitize-html@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-2.13.0.tgz#ac3620e867b7c68deab79c72bd117e2049cdd98e"
+  integrity sha512-X31WxbvW9TjIhZZNyNBZ/p5ax4ti7qsNDBDEnH4zAgmEh35YnFD1UiS6z9Cd34kKm0LslFW0KPmTQzu/oGtsqQ==
+  dependencies:
+    htmlparser2 "^8.0.0"
+
 "@types/sizzle@*":
   version "2.3.9"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.9.tgz#d4597dbd4618264c414d7429363e3f50acb66ea2"
@@ -1448,6 +1455,11 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz"
@@ -1507,7 +1519,7 @@ domhandler@5.0.3, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-domutils@^3.2.1:
+domutils@^3.0.1, domutils@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
@@ -1521,7 +1533,7 @@ emoji-regex@^8.0.0:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-entities@^4.2.0:
+entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -2130,6 +2142,16 @@ htmlparser2@10.0.0:
     domutils "^3.2.1"
     entities "^6.0.0"
 
+htmlparser2@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    entities "^4.4.0"
+
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
@@ -2280,6 +2302,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -2554,6 +2581,11 @@ nanoid@^3.3.7:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
+nanoid@^3.3.8:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
+  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
@@ -2660,6 +2692,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
@@ -2713,6 +2750,15 @@ postcss@8.4.38:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
+
+postcss@^8.3.11:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.1.tgz#e2272a1f8a807fafa413218245630b5db10a3214"
+  integrity sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==
+  dependencies:
+    nanoid "^3.3.8"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 postcss@^8.4.43:
   version "8.4.49"
@@ -2984,6 +3030,18 @@ safe-regex-test@^1.0.3:
     call-bind "^1.0.6"
     es-errors "^1.3.0"
     is-regex "^1.1.4"
+
+sanitize-html@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.14.0.tgz#bd2a7b97ee1d86a7f0e0babf3a4468f639c3a429"
+  integrity sha512-CafX+IUPxZshXqqRaG9ZClSlfPVjSxI0td7n07hk8QO2oO+9JDnlcL8iM8TWeOXOIBFgIOx6zioTzM53AOMn3g==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^8.0.0"
+    is-plain-object "^5.0.0"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
 
 scheduler@^0.23.2:
   version "0.23.2"


### PR DESCRIPTION
## 🔎 작업 내용

- sanitize-html 추가로 설치하여 현재 p 태그만 적용되는 문제를 해결하고자 (사실 그냥 거슬렸어요..ㅎㅎ) h1, h2, h3, br, stong 등등의 요소도 파싱되어 브라우저에 렌더링 할 수 있게 수정하였습니다. 
- 모집글 수정/작성 api에 application/json 형식으로 바꾸어 테스트 완료 하였습니다. 
- 메인 페이지에 있는 리스트에 h1~5 태그들이 적용되면 어색한 것 같아서 이 컴포넌트에는 해당 태그들을 허용하지 않도록 하였습니다.
  <br/>

### 작업 결과 (관련 스크린샷)

<img width="772" alt="image" src="https://github.com/user-attachments/assets/5badfac4-33e5-49f7-8c44-fbfc03488355" />
<img width="777" alt="image" src="https://github.com/user-attachments/assets/1b32d96b-4946-48c4-9c08-d56e84d539d3" />

<br/>

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #523