### PR TITLE
♻️ [#547] Refactor: 지원자 페이지 email 필드 contact_number로 변경

### DIFF
--- a/src/components/applicant-list-item/index.tsx
+++ b/src/components/applicant-list-item/index.tsx
@@ -85,7 +85,7 @@ const ApplicantListItem = ({ applicant, recruitStatus }: ApplicantListItemProps)
                 <Name>
                   {applicant.volunteer.name} ({applicant.volunteer.nickname})
                 </Name>
-                <Email>{applicant.volunteer.email}</Email>
+                <Email>{applicant.volunteer.contact_number}</Email>
               </SimpleProfile>
               <Status>{applicant.status}</Status>
             </ProfileInfoWrapper>

--- a/src/shared/types/aidrq-volunteer-list/volunteerListType.ts
+++ b/src/shared/types/aidrq-volunteer-list/volunteerListType.ts
@@ -2,7 +2,7 @@ export interface Volunteer {
   id: string;
   name: string;
   nickname: string;
-  email: string;
+  contact_number: string;
   img_url: string;
 }
 


### PR DESCRIPTION
## 🔎 작업 내용

- Volunteer 타입에 email 삭제, contact_number: string; 추가
- src/components/applicant-list-item/index.tsx에 email -> contact_number 변경

  <br/>

### 작업 결과 (관련 스크린샷)

<img width="506" alt="image" src="https://github.com/user-attachments/assets/0ceaff6c-50e5-4c9c-a02f-a1349e832509" />
<img width="464" alt="image" src="https://github.com/user-attachments/assets/126fcd70-1be2-411d-b099-ce229f57bec7" />

<br/>

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #547

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->