### PR TITLE
✨feat:상세정보페이지 로그인로직에 연결

### DIFF
--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -11,9 +11,12 @@ export default function Layout() {
     window.scrollTo(0, 0);
   }, [location.pathname]);
 
+  const hideHeaderPaths = ['/volunteer-detail', '/center-detail'];
+  const shouldShowHeader = !hideHeaderPaths.includes(location.pathname);
+
   return (
     <Wrapper>
-      <Header />
+      {shouldShowHeader && <Header />}
       <Main>
         <Outlet />
       </Main>

--- a/src/pages/detail-info-page/center/index.tsx
+++ b/src/pages/detail-info-page/center/index.tsx
@@ -1,7 +1,70 @@
+import { useNavigate } from 'react-router';
+import { useState } from 'react';
+
 import InputBox from '@/components/inputBox';
-import { DetailInfoForm, PageWrapper, SubmitButton, TitleContainer } from './indexCss';
+import { DetailInfo, DetailInfoForm, LogoutButton, PageWrapper, SubmitButton, TitleContainer } from './indexCss';
+import { useAlertDialog } from '@/store/stores/dialog/dialogStore';
+import { putCenterInfo } from './logic/putCenterInfo';
+import { useLoginStore } from '@/store/stores/login/loginStore';
+import { commonLogout } from '@/store/queries/logout-query/useCommonLogout';
+
+interface FormDataType {
+  name: string;
+  contact: string;
+  homepage_url: string;
+  introduce: string;
+}
+
+interface SubmitDataType {
+  common_basic_info: {
+    name: string;
+    contact_number: string;
+    img_url: string;
+    introduce: string;
+  };
+  homepage_url: string;
+}
 
 const CenterDetailInfoPage = () => {
+  const navigate = useNavigate();
+  const { openAlert } = useAlertDialog();
+  const clearLoginInfo = useLoginStore((state) => state.clearLoginInfo);
+
+  const [formData, setFormData] = useState<FormDataType>({
+    name: '',
+    contact: '',
+    homepage_url: '',
+    introduce: ''
+  });
+
+  const handleSubmit = async () => {
+    const submitData: SubmitDataType = {
+      common_basic_info: {
+        name: formData.name,
+        contact_number: formData.contact,
+        img_url: '',
+        introduce: formData.introduce
+      },
+      homepage_url: formData.homepage_url
+    };
+
+    try {
+      await putCenterInfo(submitData);
+      openAlert('센터 정보가 성공적으로 업데이트되었습니다.');
+      navigate('/main');
+    } catch (error) {
+      console.error('센터 정보 업데이트 중 오류 발생:', error);
+      openAlert('정보 업데이트에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  const handleInputChange = (field: keyof FormDataType, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
   return (
     <PageWrapper>
       <TitleContainer>
@@ -9,20 +72,56 @@ const CenterDetailInfoPage = () => {
         <h1>처음 방문하는 기관이신가요?</h1>
         <p>아래 정보를 입력해주세요.</p>
       </TitleContainer>
-      <DetailInfoForm onSubmit={() => console.log('기관상세정보입력폼제출')}>
+      <DetailInfoForm>
         <div>
           <label htmlFor="centerName">기관명</label>
-          <InputBox colortype="white" textType="text" placeholder="기관명을 입력해주세요." />
+          <InputBox
+            colortype="white"
+            textType="text"
+            placeholder="기관명을 입력해주세요."
+            getInputText={(value: string) => handleInputChange('name', value)}
+          />
         </div>
         <div>
           <label htmlFor="centerPhone">전화번호</label>
-          <InputBox colortype="white" textType="text" placeholder="전화번호를 입력해주세요." />
+          <InputBox
+            colortype="white"
+            textType="text"
+            placeholder="전화번호를 입력해주세요."
+            getInputText={(value: string) => handleInputChange('contact', value)}
+          />
         </div>
         <div>
           <label htmlFor="centerSiteAddress">사이트주소</label>
-          <InputBox colortype="white" textType="url" placeholder="사이트 주소를 입력해주세요." />
+          <InputBox
+            colortype="white"
+            textType="url"
+            placeholder="사이트 주소를 입력해주세요."
+            getInputText={(value: string) => handleInputChange('homepage_url', value)}
+          />
         </div>
-        <SubmitButton label="입력하기" type="blue" />
+        <div>
+          <label htmlFor="centerSiteAddress">상세정보</label>
+          <DetailInfo
+            placeholder="간단한 소개를 작성해주세요"
+            colortype="white"
+            getInputText={(value: string) => handleInputChange('introduce', value)}
+          />
+        </div>
+        <SubmitButton label="입력하기" type="blue" onClick={handleSubmit} />
+        <LogoutButton
+          label="로그아웃"
+          type="white"
+          onClick={async () => {
+            try {
+              await commonLogout();
+              clearLoginInfo();
+              window.location.href = '/main';
+            } catch (error) {
+              console.error('로그아웃 실패:', error);
+            }
+          }}
+        />
       </DetailInfoForm>
     </PageWrapper>
   );

--- a/src/pages/detail-info-page/center/indexCss.ts
+++ b/src/pages/detail-info-page/center/indexCss.ts
@@ -1,4 +1,5 @@
 import Button from '@/components/button';
+import TextArea from '@/components/textArea';
 import theme from '@/styles/theme';
 import styled from 'styled-components';
 
@@ -52,10 +53,22 @@ export const DetailInfoForm = styled.form`
   }
 `;
 
+export const DetailInfo = styled(TextArea)`
+  height: 150px;
+`;
+
 export const SubmitButton = styled(Button)`
   max-width: 460px;
   width: 100%;
   border-radius: 10px;
   height: 53px;
   margin-top: 50px;
+`;
+
+export const LogoutButton = styled(Button)`
+  max-width: 460px;
+  width: 100%;
+  border-radius: 10px;
+  height: 53px;
+  margin-top: 5px;
 `;

--- a/src/pages/detail-info-page/center/logic/putCenterInfo.ts
+++ b/src/pages/detail-info-page/center/logic/putCenterInfo.ts
@@ -1,0 +1,16 @@
+import axiosInstance from '@/api/apis';
+
+interface SubmitDataType {
+  common_basic_info: {
+    name: string;
+    contact_number: string;
+    img_url: string;
+    introduce: string;
+  };
+  homepage_url: string;
+}
+
+export const putCenterInfo = async (submitData: SubmitDataType) => {
+  const response = await axiosInstance.put('/api/user/basic-info/center', submitData);
+  return response;
+};

--- a/src/pages/detail-info-page/volunteer/index.tsx
+++ b/src/pages/detail-info-page/volunteer/index.tsx
@@ -1,12 +1,73 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import InputBox from '@/components/inputBox';
 import { DetailInfoForm, PageWrapper, SubmitButton, TitleContainer } from '../center/indexCss';
-import Select from '@/components/select';
+import { DetailInfo, LogoutButton, TabButton, TabWrapper } from './indexCss';
+import { useAlertDialog } from '@/store/stores/dialog/dialogStore';
+import { putVolunteerInfo } from './logic/putVolunteerInfo';
+import { useLoginStore } from '@/store/stores/login/loginStore';
+import { commonLogout } from '@/store/queries/logout-query/useCommonLogout';
+
+interface FormDataType {
+  name: string;
+  contact: string;
+  nickname: string;
+  gender: '남성' | '여성';
+  introduce: string;
+}
+
+interface SubmitDataType {
+  common_basic_info: {
+    name: string;
+    contact_number: string;
+    img_url: string;
+    introduce: string;
+  };
+  nickname: string;
+  gender: 'MALE' | 'FEMALE';
+}
 
 const VolunteerDetailInfoPage = () => {
-  const genderOptions = ['남성', '여성'];
+  const navigate = useNavigate();
+  const { openAlert } = useAlertDialog();
+  const clearLoginInfo = useLoginStore((state) => state.clearLoginInfo);
 
-  const handleGenderSelect = (selected: string) => {
-    console.log('선택된 성별:', selected);
+  const [formData, setFormData] = useState<FormDataType>({
+    name: '',
+    contact: '',
+    nickname: '',
+    gender: '남성',
+    introduce: ''
+  });
+
+  const handleSubmit = async () => {
+    const submitData: SubmitDataType = {
+      common_basic_info: {
+        name: formData.name,
+        contact_number: formData.contact,
+        img_url: '',
+        introduce: formData.introduce
+      },
+      nickname: formData.nickname,
+      gender: formData.gender === '남성' ? 'MALE' : 'FEMALE'
+    };
+
+    try {
+      await putVolunteerInfo(submitData);
+      openAlert('봉사자 정보가 성공적으로 업데이트되었습니다.');
+      navigate('/main');
+    } catch (error) {
+      console.error('봉사자 정보 업데이트 중 오류 발생:', error);
+      openAlert('정보 업데이트에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  const handleInputChange = (field: keyof FormDataType, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value
+    }));
   };
 
   return (
@@ -16,29 +77,73 @@ const VolunteerDetailInfoPage = () => {
         <h1>처음 방문하는 봉사자이신가요?</h1>
         <p>아래 정보를 입력해주세요.</p>
       </TitleContainer>
-      <DetailInfoForm onSubmit={() => console.log('봉사자상세정보입력폼제출')}>
+      <DetailInfoForm>
         <div>
           <label htmlFor="volunteerName">이름</label>
-          <InputBox colortype="white" textType="text" placeholder="이름을 입력해주세요." />
+          <InputBox
+            colortype="white"
+            textType="text"
+            placeholder="이름을 입력해주세요."
+            getInputText={(value: string) => handleInputChange('name', value)}
+          />
         </div>
         <div>
           <label htmlFor="volunteerPhone">전화번호</label>
-          <InputBox colortype="white" textType="text" placeholder="전화번호를 입력해주세요." />
+          <InputBox
+            colortype="white"
+            textType="text"
+            placeholder="전화번호를 입력해주세요."
+            getInputText={(value: string) => handleInputChange('contact', value)}
+          />
         </div>
         <div>
           <label htmlFor="volunteerNickName">닉네임</label>
-          <InputBox colortype="white" textType="url" placeholder="닉네임을 입력해주세요." />
+          <InputBox
+            colortype="white"
+            textType="url"
+            placeholder="닉네임을 입력해주세요."
+            getInputText={(value: string) => handleInputChange('nickname', value)}
+          />
         </div>
         <div>
           <label htmlFor="volunteerGender">성별</label>
-          <Select
-            text="성별을 선택해주세요."
-            data={genderOptions}
-            getSelectedOption={handleGenderSelect}
-            width="100%"
+          <TabWrapper>
+            <TabButton
+              label="남성"
+              type="white"
+              isActive={formData.gender === '남성'}
+              onClick={() => handleInputChange('gender', '남성')}
+            />
+            <TabButton
+              label="여성"
+              type="white"
+              isActive={formData.gender === '여성'}
+              onClick={() => handleInputChange('gender', '여성')}
+            />
+          </TabWrapper>
+        </div>
+        <div>
+          <label htmlFor="volunteerIntroduce">상세정보</label>
+          <DetailInfo
+            placeholder="간단한 소개를 작성해주세요"
+            colortype="white"
+            getInputText={(value: string) => handleInputChange('introduce', value)}
           />
         </div>
-        <SubmitButton label="입력하기" type="blue" />
+        <SubmitButton label="입력하기" type="blue" onClick={handleSubmit} />
+        <LogoutButton
+          label="로그아웃"
+          type="white"
+          onClick={async () => {
+            try {
+              await commonLogout();
+              clearLoginInfo();
+              window.location.href = '/main';
+            } catch (error) {
+              console.error('로그아웃 실패:', error);
+            }
+          }}
+        />
       </DetailInfoForm>
     </PageWrapper>
   );

--- a/src/pages/detail-info-page/volunteer/indexCss.ts
+++ b/src/pages/detail-info-page/volunteer/indexCss.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+import Button from '@/components/button';
+import TextArea from '@/components/textArea';
+
+export const TabWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const TabButton = styled(Button)<{ isActive?: boolean }>`
+  flex: 1;
+  height: 50px;
+  border-radius: 10px;
+  font-size: ${theme.fontSize.seventhSize};
+`;
+
+export const DetailInfo = styled(TextArea)`
+  height: 150px;
+`;
+
+export const LogoutButton = styled(Button)`
+  max-width: 460px;
+  width: 100%;
+  border-radius: 10px;
+  height: 53px;
+  margin-top: 5px;
+`;

--- a/src/pages/detail-info-page/volunteer/logic/putVolunteerInfo.ts
+++ b/src/pages/detail-info-page/volunteer/logic/putVolunteerInfo.ts
@@ -1,0 +1,17 @@
+import axiosInstance from '@/api/apis';
+
+interface SubmitDataType {
+  common_basic_info: {
+    name: string;
+    contact_number: string;
+    img_url: string;
+    introduce: string;
+  };
+  nickname: string;
+  gender: 'MALE' | 'FEMALE';
+}
+
+export const putVolunteerInfo = async (submitData: SubmitDataType) => {
+  const response = await axiosInstance.put('/api/user/basic-info/volunteer', submitData);
+  return response;
+};


### PR DESCRIPTION
## 🔎 작업 내용

- 상세정보입력페이지를 로그인 로직에 연결
- volunteer/center에 따라서 상세정보가 없을 시에만 상세정보 입력페이지로 이동.
- 상세설명textarea추가
- logout버튼 추가
- 입력 완료 시, 알림을 띄운 뒤 main으로 리다이렉트
- header안보이게

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- url을 수동으로 쳐서 들어가는 작업 방지
- 유효성 검사

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->