### PR TITLE
🐛fix:상세정보입력여부에 따라 라우팅처리

### DIFF
--- a/src/api/routes/index.tsx
+++ b/src/api/routes/index.tsx
@@ -28,6 +28,7 @@ import SignupPage from '@/pages/signup-page';
 import CenterDetailInfoPage from '@/pages/detail-info-page/center';
 import VolunteerDetailInfoPage from '@/pages/detail-info-page/volunteer';
 import SuccessPage from '@/pages/success-page';
+import ProtectedRoute from '@/components/route/ProtectedRoute';
 
 const MyPage = () => {
   const loginType = useLoginStore((state) => state.loginType);
@@ -79,31 +80,59 @@ const routes: RouteObject[] = [
       },
       {
         path: '/aidrqdetail/:id',
-        element: <AidRqDetailPage />
+        element: (
+          <ProtectedRoute>
+            <AidRqDetailPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/mypage',
-        element: <MyPage />
+        element: (
+          <ProtectedRoute>
+            <MyPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/mypage/adminaidreqlist',
-        element: <AdminAidRqListPage />
+        element: (
+          <ProtectedRoute>
+            <AdminAidRqListPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/mypage/adminaidreqcreate',
-        element: <AidRqCreatePage />
+        element: (
+          <ProtectedRoute>
+            <AidRqCreatePage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/mypage/adminaidreqmodify',
-        element: <AidRqModifyPage />
+        element: (
+          <ProtectedRoute>
+            <AidRqModifyPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/mypage/adminaidreqlist/:id',
-        element: <AidRqDetailAdminPage />
+        element: (
+          <ProtectedRoute>
+            <AidRqDetailAdminPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/mypage/adminaidreqlist/:id/applicantList',
-        element: <AidRqApplicantListPage />
+        element: (
+          <ProtectedRoute>
+            <AidRqApplicantListPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/login',
@@ -120,20 +149,36 @@ const routes: RouteObject[] = [
       {
         // TODO: 추후 라우팅 통합할 예정
         path: '/center-detail',
-        element: <CenterDetailInfoPage />
+        element: (
+          <ProtectedRoute>
+            <CenterDetailInfoPage />
+          </ProtectedRoute>
+        )
       },
       {
         // TODO: 추후 라우팅 통합할 예정
         path: '/volunteer-detail',
-        element: <VolunteerDetailInfoPage />
+        element: (
+          <ProtectedRoute>
+            <VolunteerDetailInfoPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/profile',
-        element: <PersonalProfilePage />
+        element: (
+          <ProtectedRoute>
+            <PersonalProfilePage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/profile/:userId',
-        element: <PersonalProfilePage />
+        element: (
+          <ProtectedRoute>
+            <PersonalProfilePage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/community',
@@ -141,19 +186,35 @@ const routes: RouteObject[] = [
       },
       {
         path: '/community/:content_id',
-        element: <CommunityDetailPage />
+        element: (
+          <ProtectedRoute>
+            <CommunityDetailPage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/communitycreate',
-        element: <CommunityCreatePage />
+        element: (
+          <ProtectedRoute>
+            <CommunityCreatePage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/communitycreate/:content_id',
-        element: <CommunityCreatePage />
+        element: (
+          <ProtectedRoute>
+            <CommunityCreatePage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/centerprofile/:center_id',
-        element: <CenterProfilePage />
+        element: (
+          <ProtectedRoute>
+            <CenterProfilePage />
+          </ProtectedRoute>
+        )
       },
       {
         path: '/findnearmyactivity',

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { type PropsWithChildren } from 'react';
+import axiosInstance from '@/api/apis';
+import { useLoginStore } from '@/store/stores/login/loginStore';
+
+const ProtectedRoute = ({ children }: PropsWithChildren) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasBasicInfo, setHasBasicInfo] = useState<boolean | null>(null);
+  const location = useLocation();
+  const loginType = useLoginStore((state) => state.loginType);
+  const token = sessionStorage.getItem('token');
+
+  useEffect(() => {
+    const checkBasicInfo = async () => {
+      try {
+        const response = await axiosInstance.get('api/user/check/basic-info');
+        setHasBasicInfo(response.data);
+      } catch (error) {
+        console.error('상세정보 확인 실패:', error);
+        setHasBasicInfo(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    // 로그인 상태일 때만 상세정보 체크
+    if (token) {
+      checkBasicInfo();
+    } else {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  if (isLoading) {
+    return null;
+  }
+
+  // 로그인 체크
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // 상세정보가 없는 경우의 리다이렉션 로직
+  if (!hasBasicInfo) {
+    // 이미 detail 페이지에 있다면 그대로 유지
+    if (location.pathname.includes('-detail')) {
+      return <>{children}</>;
+    }
+
+    // detail 페이지가 아닌 다른 페이지로 이동하려고 할 때 리다이렉션
+    const redirectPath = loginType === 'ROLE_CENTER' ? '/center-detail' : '/volunteer-detail';
+    return <Navigate to={redirectPath} replace />;
+  }
+
+  // 상세정보가 있는 경우, detail 페이지 접근 방지
+  if (hasBasicInfo && location.pathname.includes('-detail')) {
+    return <Navigate to="/main" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/pages/detail-info-page/center/index.tsx
+++ b/src/pages/detail-info-page/center/index.tsx
@@ -5,8 +5,6 @@ import InputBox from '@/components/inputBox';
 import { DetailInfo, DetailInfoForm, LogoutButton, PageWrapper, SubmitButton, TitleContainer } from './indexCss';
 import { useAlertDialog } from '@/store/stores/dialog/dialogStore';
 import { putCenterInfo } from './logic/putCenterInfo';
-import { useLoginStore } from '@/store/stores/login/loginStore';
-import { commonLogout } from '@/store/queries/logout-query/useCommonLogout';
 
 interface FormDataType {
   name: string;
@@ -28,7 +26,6 @@ interface SubmitDataType {
 const CenterDetailInfoPage = () => {
   const navigate = useNavigate();
   const { openAlert } = useAlertDialog();
-  const clearLoginInfo = useLoginStore((state) => state.clearLoginInfo);
 
   const [formData, setFormData] = useState<FormDataType>({
     name: '',
@@ -110,16 +107,10 @@ const CenterDetailInfoPage = () => {
         </div>
         <SubmitButton label="입력하기" type="blue" onClick={handleSubmit} />
         <LogoutButton
-          label="로그아웃"
+          label="건너뛰기"
           type="white"
-          onClick={async () => {
-            try {
-              await commonLogout();
-              clearLoginInfo();
-              window.location.href = '/main';
-            } catch (error) {
-              console.error('로그아웃 실패:', error);
-            }
+          onClick={() => {
+            navigate('/main');
           }}
         />
       </DetailInfoForm>

--- a/src/pages/detail-info-page/volunteer/index.tsx
+++ b/src/pages/detail-info-page/volunteer/index.tsx
@@ -6,8 +6,6 @@ import { DetailInfoForm, PageWrapper, SubmitButton, TitleContainer } from '../ce
 import { DetailInfo, LogoutButton, TabButton, TabWrapper } from './indexCss';
 import { useAlertDialog } from '@/store/stores/dialog/dialogStore';
 import { putVolunteerInfo } from './logic/putVolunteerInfo';
-import { useLoginStore } from '@/store/stores/login/loginStore';
-import { commonLogout } from '@/store/queries/logout-query/useCommonLogout';
 
 interface FormDataType {
   name: string;
@@ -31,7 +29,6 @@ interface SubmitDataType {
 const VolunteerDetailInfoPage = () => {
   const navigate = useNavigate();
   const { openAlert } = useAlertDialog();
-  const clearLoginInfo = useLoginStore((state) => state.clearLoginInfo);
 
   const [formData, setFormData] = useState<FormDataType>({
     name: '',
@@ -132,16 +129,10 @@ const VolunteerDetailInfoPage = () => {
         </div>
         <SubmitButton label="입력하기" type="blue" onClick={handleSubmit} />
         <LogoutButton
-          label="로그아웃"
+          label="건너뛰기"
           type="white"
-          onClick={async () => {
-            try {
-              await commonLogout();
-              clearLoginInfo();
-              window.location.href = '/main';
-            } catch (error) {
-              console.error('로그아웃 실패:', error);
-            }
+          onClick={() => {
+            navigate('/main');
           }}
         />
       </DetailInfoForm>


### PR DESCRIPTION
## 🔎 작업 내용

- 상세정보 미입력 시 타 페이지 이동불가 라우팅처리
- 로그아웃 버튼 대신 건너뛰기 버튼 추가
- 상세정보입력 안해도 열람은 가능한 페이지들이 있도록 처리 (ProtectedRoute 특성상 다 막아두면 오히려 코드가 복잡해짐)
- 로그인 안해도 기능이 필요한 페이지들 블럭처리 (이 부분은 회의 후에 수정 가능)

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->