### PR TITLE
🐛 [#585] Fix: 기관이 조회하는 리뷰 모달에 volunteerId store에서 가져오기

### DIFF
--- a/src/features/review-read-modal/index.tsx
+++ b/src/features/review-read-modal/index.tsx
@@ -34,7 +34,8 @@ const ReviewReadModal = ({ handleCloseReviewModal, reviewId, isCenterReview = tr
   const { reviewData, volunteerData } = useFindReview({ isCenterReview, reviewId });
   const { formatDate } = useDateFormat();
   const navigate = useNavigate();
-  const roleType = useLoginStore((state) => state.loginType);
+  // const roleType = useLoginStore((state) => state.loginType);
+  const { loginType: roleType, myRoleId: volunteerId } = useLoginStore();
 
   if (!reviewData) return null;
 
@@ -83,7 +84,7 @@ const ReviewReadModal = ({ handleCloseReviewModal, reviewId, isCenterReview = tr
                 label="프로필 확인하기"
                 type="blue"
                 onClick={() => {
-                  navigate(`/profile/${volunteerData?.volunteer_id}`);
+                  navigate(`/profile/${volunteerId}`);
                 }}
               />
             </ProfileBox>

--- a/src/features/review-read-modal/logic/useFindReview.tsx
+++ b/src/features/review-read-modal/logic/useFindReview.tsx
@@ -35,7 +35,7 @@ export const useFindReview = ({ isCenterReview, reviewId }: useFindReviewProps):
     return { reviewData: undefined };
   }
 
-  // console.log('review data:', reviewData);
+  console.log('review data:', reviewData);
   // if (isReviewLoading) console.log('리뷰 로딩중');
 
   return {

--- a/src/store/queries/volunteer-profile/useFetchPersonProfile.ts
+++ b/src/store/queries/volunteer-profile/useFetchPersonProfile.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/apis';
 
 const fetchPersonProfile = async (volunteerId: string) => {
-  const res = await axiosInstance.get(`/api/volunteer/profile/user-id/${volunteerId}`);
+  const res = await axiosInstance.get(`/api/volunteer/profile/volunteer-id/${volunteerId}`);
   return res.data;
 };
 


### PR DESCRIPTION
지금 봉사자 프로필 데이터에 volunteerId 없음

## 🔎 작업 내용

- 기관이 리뷰 모달 조회할 때 작성자 프로필에 volunteerId를 volunteerData에서 가져오고 있는데 현재 api 응답에는 volunteerId로 쓸 수 있는 게 없었습니다. 
- store에서 myRoleId를 가져와 volunteerId로 사용하였습니다. 

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #585

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->