### PR TITLE
🐛 [#592] Fix: 모집글 센터 프로필, 센터 프로필 페이지 itemName -> item_name으로 변경

### DIFF
--- a/src/features/aidreq-detail-center-profile/_components/info-container/index.tsx
+++ b/src/features/aidreq-detail-center-profile/_components/info-container/index.tsx
@@ -18,7 +18,7 @@ const InfoContainer: React.FC<InfoContainerProps> = ({ centerProfile }) => {
       <Explain>{centerProfile.introduce}</Explain>
       <PreferItemContainer>
         <p>이러한 지원이 필요해요!</p>
-        {centerProfile.prefer_items?.map((item) => <PreferItem label={item.itemName}></PreferItem>)}
+        {centerProfile.prefer_items?.map((item) => <PreferItem label={item.item_name}></PreferItem>)}
       </PreferItemContainer>
     </Wrapper>
   );

--- a/src/features/center-profile-prefer-item-box/index.tsx
+++ b/src/features/center-profile-prefer-item-box/index.tsx
@@ -9,7 +9,7 @@ const ProfilePreferItemBox = ({ preferItems }: { preferItems: centerPreferItemTy
       <div className="preferItemWrap">
         {preferItems.map((v, i) => (
           <div key={i} className="preferItem">
-            {v.itemName}
+            {v.item_name}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## 🔎 작업 내용

- 모집글 센터 프로필, 센터 프로필 페이지 itemName -> item_name으로 변경

  <br/>

### 작업 결과 (관련 스크린샷)

<img width="848" alt="image" src="https://github.com/user-attachments/assets/c0c98ee3-538a-44df-ae87-b482b96de017" />
<img width="877" alt="image" src="https://github.com/user-attachments/assets/fb8e0869-6a2b-4bd9-9754-30db0c3df374" />

<br/>


## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #592

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->