### PR TITLE
🐛 Bug: tinymce api key 넣어주기

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           VITE_APP_BASE_URL: ${{ secrets.VITE_APP_BASE_URL }}
           VITE_APP_JAVASCRIPT_KEY: ${{ secrets.VITE_APP_JAVASCRIPT_KEY }}
+          VITE_APP_TINYMCE_API_KEY: ${{ secrets.VITE_APP_TINYMCE_API_KEY }}
         run: yarn build
       
       - name: 배포              

--- a/src/components/tinyMCE-editor/index.tsx
+++ b/src/components/tinyMCE-editor/index.tsx
@@ -163,7 +163,6 @@ export const TinyMceContainer = ({
           'code',
           'fullscreen',
           'image',
-          'editimage',
           'insertdatetime',
           'media',
           'table',


### PR DESCRIPTION
## 🔎 작업 내용

- git secrets랑 CICD 파일에 api key 넣어줬습니다.
- editimage 기능은 다른 api key 필요해서 뺐습니다.
- 
  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

- Issue: #602 

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->